### PR TITLE
Enhance TUI experience with theme, markdown, and input improvements

### DIFF
--- a/lib/homunculus/interfaces/tui.rb
+++ b/lib/homunculus/interfaces/tui.rb
@@ -3,6 +3,13 @@
 require "sequel"
 require "fileutils"
 require "io/console"
+require_relative "tui/theme"
+require_relative "tui/input_buffer"
+require_relative "tui/activity_indicator"
+require_relative "tui/command_registry"
+require_relative "tui/message_renderer"
+require_relative "../sag/llm_adapter"
+require_relative "../sag/pipeline_factory"
 
 module Homunculus
   module Interfaces
@@ -23,40 +30,14 @@ module Homunculus
     # input) rather than clearing the full screen on every keystroke.
     class TUI
       include SemanticLogger::Loggable
+      include TUI::Theme
 
       HEADER_ROWS  = 3
       STATUS_ROWS  = 1
       INPUT_ROWS   = 2
       CHROME_ROWS  = HEADER_ROWS + STATUS_ROWS + INPUT_ROWS
 
-      ROLE_COLORS = {
-        user: :cyan,
-        assistant: :green,
-        system: :yellow,
-        error: :red,
-        info: :dim
-      }.freeze
-
       AGENT_NAME = "Homunculus"
-
-      ANSI_CODES = {
-        reset: "\e[0m",
-        bold: "\e[1m",
-        dim: "\e[2m",
-        italic: "\e[3m",
-        underline: "\e[4m",
-        reverse: "\e[7m",
-        red: "\e[31m",
-        green: "\e[32m",
-        yellow: "\e[33m",
-        blue: "\e[34m",
-        magenta: "\e[35m",
-        cyan: "\e[36m",
-        white: "\e[37m",
-        bright_blue: "\e[94m",
-        bright_green: "\e[92m",
-        bright_cyan: "\e[96m"
-      }.freeze
 
       def initialize(config:, provider_name: nil, model_override: nil)
         @config         = config
@@ -66,10 +47,18 @@ module Homunculus
         @session        = nil
         @agent_loop     = nil
         @messages       = []   # [{role:, text:, lines: []}]
+        @messages_mutex = Mutex.new
+        @overlay_content = nil # nil or array of lines (help/status overlay); cleared on next input
+        @suggestion_lines = nil # nil or array of strings (slash command suggestions); transient, not in @messages
+        @command_registry = TUI::CommandRegistry.new
         @scroll_offset  = 0    # lines scrolled from the bottom
         @streaming_buf  = nil  # active streaming message entry
+        @streaming_output_tokens_estimate = nil # live estimate during stream (Integer or nil)
         @agent_name     = AGENT_NAME
         @identity_line  = load_identity
+        @current_tier   = nil
+        @current_model  = nil
+        @current_escalated_from = nil
 
         setup_components!
       end
@@ -77,6 +66,7 @@ module Homunculus
       def start
         @running = true
         @session = Session.new
+        @session_start_time = Time.now
 
         setup_signal_handlers
         @scheduler_manager&.start
@@ -87,6 +77,7 @@ module Homunculus
         end
       ensure
         teardown_terminal
+        print_session_summary
         shutdown
       end
 
@@ -97,6 +88,16 @@ module Homunculus
       def setup_components!
         @audit        = Security::AuditLogger.new(@config.security.audit_log_path)
         @memory_store = build_memory_store
+        @activity_indicator = ActivityIndicator.new(redraw: -> { refresh_status_bar })
+
+        # Build provider infrastructure first — tool registry needs it for SAG wiring
+        if use_models_router?
+          build_models_router_infrastructure!
+        else
+          model_config = resolve_model_config
+          @provider = Agent::ModelProvider.new(model_config)
+        end
+
         @tool_registry = build_tool_registry
         @prompt_builder = Agent::PromptBuilder.new(
           workspace_path: @config.agent.workspace_path,
@@ -104,17 +105,17 @@ module Homunculus
           memory: @memory_store
         )
 
-        if use_models_router?
-          @agent_loop = build_loop_with_models_router
+        status_cb = build_status_callback
+        if @models_router
+          @agent_loop = build_loop_with_models_router(status_callback: status_cb)
         else
-          model_config = resolve_model_config
-          @provider   = Agent::ModelProvider.new(model_config)
           @agent_loop = Agent::Loop.new(
             config: @config,
             provider: @provider,
             tools: @tool_registry,
             prompt_builder: @prompt_builder,
-            audit: @audit
+            audit: @audit,
+            status_callback: status_cb
           )
         end
 
@@ -129,7 +130,7 @@ module Homunculus
         @models_toml_path ||= File.expand_path("config/models.toml", Dir.pwd)
       end
 
-      def build_loop_with_models_router
+      def build_models_router_infrastructure!
         models_toml   = TomlRB.load_file(models_toml_path)
         ollama_config = (models_toml.dig("providers", "ollama") || {}).dup
         ollama_config["base_url"] =
@@ -139,42 +140,62 @@ module Homunculus
           ollama_config["timeout_seconds"] ||
           models_toml.dig("defaults", "timeout_seconds") || 120
 
-        ollama_provider = Agent::Models::OllamaProvider.new(config: ollama_config)
-        default_model   = @config.models[:local]&.default_model || @config.models[:local]&.model
+        @ollama_provider = Agent::Models::OllamaProvider.new(config: ollama_config)
+        default_model    = @config.models[:local]&.default_model || @config.models[:local]&.model
 
+        @models_toml_data = models_toml
         if default_model
-          models_toml["tiers"] ||= {}
-          models_toml["tiers"]["workhorse"] ||= {}
-          models_toml["tiers"]["workhorse"] =
-            models_toml["tiers"]["workhorse"].merge("model" => default_model)
+          @models_toml_data["tiers"] ||= {}
+          @models_toml_data["tiers"]["workhorse"] ||= {}
+          @models_toml_data["tiers"]["workhorse"] =
+            @models_toml_data["tiers"]["workhorse"].merge("model" => default_model)
         end
 
-        models_router = Agent::Models::Router.new(
-          config: models_toml,
-          providers: { ollama: ollama_provider }
+        @models_router = Agent::Models::Router.new(
+          config: @models_toml_data,
+          providers: { ollama: @ollama_provider }
         )
+      end
 
+      def build_loop_with_models_router(status_callback: nil)
         stream_cb = build_stream_callback
         Agent::Loop.new(
           config: @config,
-          models_router: models_router,
+          models_router: @models_router,
           stream_callback: stream_cb,
           tools: @tool_registry,
           prompt_builder: @prompt_builder,
-          audit: @audit
+          audit: @audit,
+          status_callback: status_callback
         )
       end
 
       def build_stream_callback
         lambda do |chunk|
-          if @streaming_buf.nil?
-            @streaming_buf = { role: :assistant, text: +"", lines: [] }
-            @messages << @streaming_buf
+          first_chunk = false
+          @messages_mutex.synchronize do
+            if @streaming_buf.nil?
+              @streaming_buf = { role: :assistant, text: +"", lines: [], timestamp: Time.now }
+              @messages << @streaming_buf
+              first_chunk = true
+            end
+            @streaming_buf[:text] << chunk
+            @streaming_output_tokens_estimate = estimate_output_tokens(@streaming_buf[:text])
           end
-          @streaming_buf[:text] << chunk
+          @activity_indicator.stop if first_chunk
           refresh_chat_panel
           refresh_status_bar
         end
+      end
+
+      # Heuristic: word_count * 1.3 or char_count / 4 (whichever is larger).
+      def estimate_output_tokens(text)
+        return 0 if text.nil? || text.empty?
+
+        words = text.split(/\s+/).size
+        by_words = (words * 1.3).round
+        by_chars = (text.length / 4).round
+        [by_words, by_chars].max
       end
 
       def resolve_model_config
@@ -208,7 +229,45 @@ module Homunculus
           registry.register(Tools::MemorySave.new(memory_store: @memory_store))
           registry.register(Tools::MemoryDailyLog.new(memory_store: @memory_store))
         end
+
+        register_sag_tool(registry) if @config.sag.enabled
         registry
+      end
+
+      def register_sag_tool(registry)
+        llm_adapter = build_sag_llm_adapter
+        return unless llm_adapter
+
+        embedder = @memory_store&.respond_to?(:embedder) ? @memory_store.embedder : nil
+        factory = SAG::PipelineFactory.new(
+          config: @config.sag,
+          llm_adapter: llm_adapter,
+          embedder: embedder
+        )
+        registry.register(Tools::WebResearch.new(pipeline_factory: factory))
+        logger.info("SAG web_research tool registered")
+      rescue StandardError => e
+        logger.warn("SAG tool registration failed — web_research unavailable", error: e.message)
+      end
+
+      def build_sag_llm_adapter
+        if @models_router
+          SAG::LLMAdapter.new(router: @models_router)
+        elsif @provider
+          SAG::LLMAdapter.new(provider: @provider)
+        end
+      end
+
+      def build_status_callback
+        lambda do |event, name|
+          case event
+          when :tool_start
+            label = name == "web_research" ? "Searching the web..." : "Running #{name}..."
+            @activity_indicator&.update(label)
+          when :tool_end
+            @activity_indicator&.update("Processing results...")
+          end
+        end
       end
 
       def build_memory_store
@@ -281,7 +340,14 @@ module Homunculus
         $stdout.write("\e[?1049h") # enter alternate screen
         $stdout.write("\e[?25l")   # hide cursor
         $stdout.flush
-        yield
+
+        # Raw stdin: no echo, no line buffering — so arrow keys send escape sequences
+        # that we can read and handle instead of being echoed as ^[[D etc.
+        if $stdin.respond_to?(:raw)
+          $stdin.raw { yield }
+        else
+          yield
+        end
       ensure
         $stdout.write("\e[?25h")   # show cursor
         $stdout.write("\e[?1049l") # exit alternate screen
@@ -367,36 +433,57 @@ module Homunculus
 
       def render_header
         move_to(1, 1)
-        $stdout.write(paint(horizontal_rule("═"), :bright_blue))
+        $stdout.write(paint(horizontal_rule(Theme::HEADER_TOP_CHAR), :accent))
         move_to(1, 2)
-        date_str   = Time.now.strftime("%Y-%m-%d")
-        title      = " #{AGENT_NAME} — #{@identity_line}"
-        right_info = "#{date_str} "
-        gap        = [term_width - visible_len(title) - visible_len(right_info), 0].max
+        date_str = Time.now.strftime("%A, %b %-d")
+        title_centered = "#{Theme::HEADER_TITLE_FLANK} #{AGENT_NAME} #{Theme::HEADER_TITLE_FLANK}"
+        title_len = visible_len(title_centered)
+        date_len = visible_len(date_str)
+        left_pad = [(term_width - title_len) / 2, 0].max
+        right_pad = [term_width - left_pad - title_len - 1 - date_len, 0].max
         $stdout.write(
-          paint(title, :bold) +
-          (" " * gap) +
-          paint(right_info, :dim)
+          (" " * left_pad) +
+          paint(title_centered, :bold) +
+          (" " * right_pad) +
+          " " +
+          paint(date_str, :muted)
         )
         move_to(1, 3)
-        $stdout.write(paint(horizontal_rule("─"), :dim))
+        tagline = @identity_line.to_s.strip
+        if tagline.empty?
+          $stdout.write(paint(horizontal_rule(Theme::HEADER_BOTTOM_CHAR), :muted))
+        else
+          $stdout.write(paint(" #{tagline}", :muted))
+        end
         $stdout.flush
       end
 
       # ── Chat Panel ─────────────────────────────────────────────────
 
       def render_chat_panel
-        lines = build_chat_lines
+        lines  = build_chat_lines
         total  = lines.length
         window = chat_rows
-        start  = [total - window - @scroll_offset, 0].max
-        slice  = lines[start, window] || []
+        max_scroll = [total - window, 0].max
+        show_above = @scroll_offset < max_scroll && max_scroll.positive?
+        show_below = @scroll_offset.positive?
+        content_rows = window - (show_above ? 1 : 0) - (show_below ? 1 : 0)
+        start = [total - content_rows - @scroll_offset, 0].max
+        slice = lines[start, content_rows] || []
 
-        (0...window).each do |i|
-          row = HEADER_ROWS + 1 + i
+        (0...window).each do |r|
+          row = HEADER_ROWS + 1 + r
           move_to(1, row)
           clear_line
-          $stdout.write(slice[i] || "")
+          line_str = if r.zero? && show_above
+                       paint("▲ more above", :muted)
+                     elsif r == window - 1 && show_below
+                       paint("▼ more below", :muted)
+                     else
+                       idx = r - (show_above ? 1 : 0)
+                       slice[idx] || ""
+                     end
+          $stdout.write(line_str)
         end
         $stdout.flush
       end
@@ -407,64 +494,56 @@ module Homunculus
 
       def build_chat_lines
         w = inner_width
-        all_lines = []
-        @messages.each do |msg|
-          all_lines.concat(render_message(msg, w))
-          all_lines << ""
-        end
-        all_lines
-      end
+        return @overlay_content.flat_map { |line| wrap_plain_line(line, w) }.map { |l| paint(l, :muted) } if @overlay_content
 
-      def render_message(msg, width)
-        role  = msg[:role]
-        text  = msg[:text].to_s
-        label = role_label(role)
-        color = ROLE_COLORS.fetch(role, :white)
-        prefix_plain = "#{label}: "
-        indent       = " " * visible_len(prefix_plain)
-
-        lines = []
-        text.split("\n").each_with_index do |para, para_idx|
-          words = para.split
-          current_line = para_idx.zero? ? prefix_plain : indent
-          words.each do |word|
-            if visible_len(current_line) + visible_len(word) + 1 > width
-              lines << paint_role_line(current_line, color, para_idx.zero? && lines.empty?)
-              current_line = indent + word
-            else
-              current_line += (current_line == indent || current_line == prefix_plain ? "" : " ") + word
+        renderer = TUI::MessageRenderer.new(width: w, agent_name: @agent_name)
+        @messages_mutex.synchronize do
+          all_lines = []
+          prev_role = nil
+          prev_date = nil
+          @messages.each do |msg|
+            msg_date = msg[:timestamp] ? msg[:timestamp].to_date : nil
+            if prev_date && msg_date && prev_date != msg_date
+              all_lines << paint(date_separator_line(msg[:timestamp], w), :muted)
             end
+            if prev_role && prev_role != msg[:role]
+              all_lines << paint(turn_separator_line(w), :muted)
+            end
+            all_lines.concat(renderer.render(msg))
+            all_lines << ""
+            prev_role = msg[:role]
+            prev_date = msg_date
           end
-          lines << paint_role_line(current_line, color, para_idx.zero? && lines.empty?) unless current_line.strip.empty?
+          all_lines
         end
-        lines.empty? ? [paint_role_line(prefix_plain, color, true)] : lines
       end
 
-      def paint_role_line(line, color, is_label_line)
-        return line if line.strip.empty?
+      def turn_separator_line(width)
+        seg = Theme::TURN_SEPARATOR + " "
+        (seg * ((width / seg.length) + 1))[0, width]
+      end
 
-        if is_label_line
-          label_end = line.index(": ")
-          if label_end
-            label_part = line[0..(label_end + 1)]
-            rest_part  = line[(label_end + 2)..]
-            paint(label_part, color, :bold) + paint(rest_part.to_s, :reset)
+      def date_separator_line(ts, width)
+        str = "── #{ts.strftime('%B %d, %Y')} ──"
+        pad = [width - visible_len(str), 0].max
+        " " * (pad / 2) + str + " " * (pad - pad / 2)
+      end
+
+      def wrap_plain_line(text, width)
+        words = text.to_s.split
+        lines = []
+        current = +""
+        words.each do |word|
+          if visible_len(current) + visible_len(word) + 1 > width
+            lines << current.strip.dup unless current.strip.empty?
+            current = +""
           else
-            paint(line, color)
+            current << " " unless current.empty?
           end
-        else
-          paint(line, :reset)
+          current << word
         end
-      end
-
-      def role_label(role)
-        case role
-        when :user      then "You"
-        when :assistant then AGENT_NAME
-        when :system    then "System"
-        when :error     then "Error"
-        else                 role.to_s.capitalize
-        end
+        lines << current.strip unless current.strip.empty?
+        lines.empty? ? [""] : lines
       end
 
       # ── Status Bar ─────────────────────────────────────────────────
@@ -472,7 +551,7 @@ module Homunculus
       def render_status_bar
         row = HEADER_ROWS + chat_rows + 1
         move_to(1, row)
-        clear_line
+        # Overwrite in place (content is padded to term_width). Avoid clear_line to reduce blink.
         $stdout.write(status_bar_content)
         $stdout.flush
       end
@@ -482,32 +561,105 @@ module Homunculus
       end
 
       def status_bar_content
-        parts = [
-          model_tier_label,
-          token_usage_label,
-          turn_label,
-          session_status_label
-        ]
-        bar = " #{parts.compact.join("  |  ")}"
-        pad = [term_width - visible_len(bar), 0].max
-        paint(bar + (" " * pad), :reverse)
+        status_part = if @activity_indicator&.running?
+                        "#{@activity_indicator.frame_char} #{@activity_indicator.message}"
+                      elsif @session&.pending_tool_call
+                        "⚠ awaiting confirm"
+                      elsif @scroll_offset.positive?
+                        "↕ scrolled"
+                      else
+                        session_status_label
+                      end
+        sep = Theme::STATUS_SEP
+        model_short = status_bar_model_label
+        model_style = model_tier_style
+        sections = [
+          model_short ? "#{Theme::ROLE_ASSISTANT} #{model_short}" : nil,
+          token_usage_label ? "#{token_usage_label} tokens" : nil,
+          turn_label ? turn_label.sub(/\Aturns: /, "turn ") : nil,
+          elapsed_session_time,
+          status_part
+        ].compact
+        raw = sections.join(sep)
+        pad = [term_width - visible_len(" #{raw} "), 0].max
+        out = " "
+        sections.each_with_index do |s, i|
+          out += paint(sep, :muted) if i.positive?
+          if i == 0 && model_style
+            out += paint(s, model_style)
+          elsif i == sections.length - 1 && @session&.pending_tool_call
+            out += paint(s, :accent)
+          else
+            out += paint(s, :muted)
+          end
+        end
+        out + (" " * pad) + " "
+      end
+
+      def elapsed_session_time
+        return nil unless @session_start_time
+
+        elapsed = (Time.now - @session_start_time).to_i
+        if elapsed >= 3600
+          h = elapsed / 3600
+          m = (elapsed % 3600) / 60
+          "#{h}h #{m}m"
+        else
+          m = elapsed / 60
+          s = elapsed % 60
+          "#{m}m #{s}s"
+        end
+      end
+
+      def status_bar_model_label
+        base = if @current_tier && @current_model
+                 @current_tier.to_s
+               elsif use_models_router?
+                 "router"
+               else
+                 @provider_name.to_s
+               end
+        @current_escalated_from ? "#{base} ⚡ escalated from #{@current_escalated_from}" : base
       end
 
       def model_tier_label
-        tier = if use_models_router?
-                 "router"
-               else
-                 @provider_name
-               end
-        "model: #{tier}"
+        if @current_tier && @current_model
+          label = "model: #{@current_tier} (#{@current_model})"
+          label += " ⚡ escalated from #{@current_escalated_from}" if @current_escalated_from
+          label
+        elsif use_models_router?
+          "model: router"
+        else
+          "model: #{@provider_name}"
+        end
+      end
+
+      # Style for the model segment: :green (local), :yellow (cloud), :bg_red (escalated).
+      def model_tier_style
+        return nil unless @current_tier
+
+        return :bg_red if @current_escalated_from
+        return :yellow if cloud_tier?(@current_tier)
+
+        :green
+      end
+
+      def cloud_tier?(tier_name)
+        tier_name.to_s.start_with?("cloud_")
       end
 
       def token_usage_label
         return nil unless @session
 
-        in_t  = @session.total_input_tokens
+        in_t = @session.total_input_tokens
         out_t = @session.total_output_tokens
-        "tokens: #{in_t}↓ #{out_t}↑"
+        estimate = @messages_mutex.synchronize { @streaming_output_tokens_estimate }
+        if estimate&.positive?
+          live_out = out_t + estimate
+          "tokens: #{in_t}↓ #{live_out}↑ (+#{estimate}⚡)"
+        else
+          "tokens: #{in_t}↓ #{out_t}↑"
+        end
       end
 
       def turn_label
@@ -525,22 +677,121 @@ module Homunculus
 
       # ── Input Line ─────────────────────────────────────────────────
 
-      def render_input_line(input_text = "")
+      def update_suggestion_lines(input_buffer)
+        buf_str = input_buffer.respond_to?(:to_s) ? input_buffer.to_s : input_buffer.to_str
+        if buf_str.start_with?("/")
+          @suggestion_lines = @command_registry.suggestions_with_descriptions(buf_str)
+          @suggestion_prefix = buf_str
+        else
+          @suggestion_lines = nil
+          @suggestion_prefix = nil
+        end
+      end
+
+      # Completes input_buffer to the first suggestion when buffer starts with / and is a prefix. Returns true if completion was applied.
+      def apply_tab_completion(input_buffer)
+        buf_str = input_buffer.to_s
+        return false unless buf_str.start_with?("/") && @suggestion_lines&.any?
+
+        top = @suggestion_lines.first
+        top_cmd = top.is_a?(Hash) ? top[:command] : top
+        return false unless top_cmd && (buf_str == top_cmd || top_cmd.start_with?(buf_str))
+
+        input_buffer.clear
+        top_cmd.each_char { |c| input_buffer.insert(c) }
+        update_suggestion_lines(input_buffer)
+        true
+      end
+
+      # No args: empty line + hide cursor. With input_buffer: draw text + show cursor. Legacy: (text, cursor).
+      def render_input_line(input_buffer_or_text = nil, cursor_pos = nil)
         status_row = HEADER_ROWS + chat_rows + 1
-        move_to(1, status_row + 1)
+        input_row  = status_row + 2
+        suggestion_entries = @suggestion_lines&.any? ? @suggestion_lines.first(5) : []
+
+        # Only redraw separator line on full refresh (nil). During typing it never changes — avoids blink.
+        if input_buffer_or_text.nil?
+          move_to(1, status_row + 1)
+          clear_line
+          $stdout.write(paint(horizontal_rule(Theme::SEPARATOR_CHAR), :muted))
+        end
+
+        if suggestion_entries.any?
+          prefix = @suggestion_prefix.to_s
+          suggestion_entries.each_with_index do |entry, i|
+            move_to(1, input_row - 1 - i)
+            clear_line
+            cmd = entry.is_a?(Hash) ? entry[:command] : entry
+            desc = entry.is_a?(Hash) ? entry[:description] : nil
+            line_str = desc ? "#{cmd} — #{desc}" : cmd.to_s
+            if prefix.empty? || !cmd.to_s.start_with?(prefix)
+              $stdout.write(paint(line_str, :muted))
+            else
+              $stdout.write(paint(cmd.to_s[0, prefix.length], :accent))
+              $stdout.write(paint((cmd.to_s[prefix.length..] || "") + (desc ? " — #{desc}" : ""), :muted))
+            end
+          end
+        else
+          # Clear suggestion rows when not showing suggestions so stale "/confirm" etc. doesn't persist
+          (0..4).each do |i|
+            move_to(1, input_row - 1 - i)
+            clear_line
+          end
+          # Restore the grey separator line above input (same row as first suggestion slot)
+          move_to(1, status_row + 1)
+          $stdout.write(paint(horizontal_rule(Theme::SEPARATOR_CHAR), :muted))
+        end
+
+        move_to(1, input_row)
         clear_line
-        $stdout.write(paint(horizontal_rule("─"), :dim))
-        move_to(1, status_row + 2)
-        clear_line
-        prompt = paint("> ", :cyan, :bold)
-        $stdout.write(prompt + input_text)
+        if input_buffer_or_text.nil?
+          $stdout.write("\e[?25l")
+          prompt = paint("#{Theme::PROMPT_CHAR} ", :user, :bold)
+          $stdout.write(prompt)
+          $stdout.write(paint("Type a message...", :muted))
+        else
+          text, cursor = if input_buffer_or_text.respond_to?(:cursor)
+                           [input_buffer_or_text.to_s, input_buffer_or_text.cursor]
+                         else
+                           t = input_buffer_or_text.to_s
+                           p = cursor_pos.nil? ? t.length : cursor_pos
+                           [t, p.clamp(0, t.length)]
+                         end
+          $stdout.write("\e[?25h")
+          prompt = paint("#{Theme::PROMPT_CHAR} ", :user, :bold)
+          prompt_len = visible_len("#{Theme::PROMPT_CHAR} ")
+          display_text = text
+          display_text = nil if text.empty? # show placeholder below
+          text_len = visible_len(display_text || "")
+          char_count_str = (text.length > 100 ? " #{text.length} chars" : "")
+          char_count_visible = char_count_str.length
+          if display_text.nil?
+            $stdout.write(prompt)
+            $stdout.write(paint("Type a message...", :muted))
+            col = 1 + prompt_len
+          elsif char_count_visible.positive? && (prompt_len + text_len + char_count_visible <= term_width)
+            $stdout.write(prompt + display_text)
+            pad = term_width - prompt_len - text_len - char_count_visible
+            $stdout.write(" " * pad) if pad.positive?
+            $stdout.write(paint(char_count_str, :muted))
+            col = 1 + prompt_len + (visible_len(text[0, cursor]) || 0)
+          else
+            $stdout.write(prompt + display_text)
+            col = 1 + prompt_len + (visible_len(text[0, cursor]) || 0)
+          end
+          $stdout.write("\e[#{input_row};#{col}H")
+        end
         $stdout.flush
       end
 
       # ── Input Loop ─────────────────────────────────────────────────
 
       def input_loop
-        push_info_message("Type 'help' for commands. Ctrl+C to exit.")
+        # Warm time-aware greeting as first assistant message; session context as info.
+        @messages_mutex.synchronize do
+          @messages << { role: :assistant, text: warm_greeting_text, timestamp: Time.now }
+          @messages << { role: :info, text: session_context_line, timestamp: Time.now }
+        end
         refresh_all
 
         while @running
@@ -549,12 +800,15 @@ module Homunculus
           break if input.nil?
 
           input = input.scrub.strip
+          had_overlay = !@overlay_content.nil?
+          @overlay_content = nil
+          refresh_all if had_overlay
           process_input(input)
         end
       end
 
       def read_line
-        buf = +""
+        input_buffer = TUI::InputBuffer.new
         while @running
           begin
             char = $stdin.read_nonblock(1)
@@ -567,28 +821,77 @@ module Homunculus
 
           case char
           when "\r", "\n"
-            return buf
+            return input_buffer.to_s
           when "\x03" # Ctrl+C
             @running = false
             return nil
-          when "\x7f", "\b" # backspace / delete
-            buf = buf[0..-2] || ""
-            render_input_line(buf)
+          when "\t" # Tab — complete to top suggestion when buffer starts with /
+            apply_tab_completion(input_buffer)
+            render_input_line(input_buffer)
+          when "\x01" # Ctrl+A — home
+            input_buffer.move_home
+            update_suggestion_lines(input_buffer)
+            render_input_line(input_buffer)
+          when "\x05" # Ctrl+E — end
+            input_buffer.move_end
+            render_input_line(input_buffer)
+          when "\x15" # Ctrl+U — clear input line
+            input_buffer.clear
+            update_suggestion_lines(input_buffer)
+            render_input_line(input_buffer)
+          when "\x0C" # Ctrl+L — redraw screen
+            refresh_all
+            render_input_line(input_buffer)
+          when "\x17" # Ctrl+W — delete word backward
+            input_buffer.delete_word_backward
+            update_suggestion_lines(input_buffer)
+            render_input_line(input_buffer)
+          when "\x7f", "\b" # backspace
+            input_buffer.backspace
+            update_suggestion_lines(input_buffer)
+            render_input_line(input_buffer)
           when "\x1b" # escape sequences (arrow keys etc.)
-            consume_escape_sequence
+            consume_escape_sequence(input_buffer)
+            render_input_line(input_buffer)
           else
-            buf << char if char.ord >= 32
-            render_input_line(buf)
+            input_buffer.insert(char) if char.ord >= 32
+            update_suggestion_lines(input_buffer)
+            render_input_line(input_buffer)
           end
         end
         nil
       end
 
-      def consume_escape_sequence
+      def consume_escape_sequence(input_buffer)
+        @suggestion_lines = nil
+        seq = read_escape_sequence
+        case seq
+        when "[D" then apply_cursor_action(input_buffer, :move_left)
+        when "[C" then apply_cursor_action(input_buffer, :move_right)
+        when "[H" then apply_cursor_action(input_buffer, :move_home)
+        when "[F" then apply_cursor_action(input_buffer, :move_end)
+        when "[1;5C" then apply_cursor_action(input_buffer, :move_word_right)
+        when "[1;5D" then apply_cursor_action(input_buffer, :move_word_left)
+        when "[A", "[1;2A", "[B", "[1;2B", "[5~", "[6~"
+          handle_scroll_keys(seq)
+        end
+      end
+
+      # Read the rest of an escape sequence after \e. Waits briefly so we don't leave bytes in the buffer.
+      def read_escape_sequence
         seq = $stdin.read_nonblock(8)
-        handle_scroll_keys(seq)
+        seq
       rescue IO::WaitReadable
-        nil
+        $stdin.wait_readable(0.1)
+        seq = $stdin.read_nonblock(8)
+        seq
+      rescue EOFError
+        ""
+      end
+
+      def apply_cursor_action(input_buffer, method_name)
+        input_buffer.public_send(method_name)
+        render_input_line(input_buffer)
       end
 
       def handle_scroll_keys(seq)
@@ -612,10 +915,27 @@ module Homunculus
       end
 
       def process_input(input)
-        case input.downcase
+        @overlay_content = nil
+        stripped = input.to_s.strip
+
+        if stripped.start_with?("/")
+          cmd_key = @command_registry.match(stripped)
+          if cmd_key
+            dispatch_slash_command(cmd_key)
+          else
+            @overlay_content = ["Unknown command. Type /help for available commands."]
+            refresh_all
+          end
+          return
+        end
+
+        # Bare-word dispatch (backward compatibility)
+        case stripped.downcase
         when "", nil
           nil
         when "exit", "quit", ":q"
+          push_info_message("Shutting down...")
+          refresh_all
           @running = false
         when "help"
           show_help
@@ -626,11 +946,30 @@ module Homunculus
         when "deny"
           handle_deny
         when "clear"
-          @messages.clear
+          @messages_mutex.synchronize { @messages.clear }
           @scroll_offset = 0
           refresh_all
         else
           handle_message(input)
+        end
+      end
+
+      def dispatch_slash_command(cmd_key)
+        handler = TUI::CommandRegistry::COMMANDS[cmd_key][:handler]
+        case handler
+        when :show_help then show_help
+        when :show_status then show_status
+        when :clear
+          @messages_mutex.synchronize { @messages.clear }
+          @scroll_offset = 0
+          refresh_all
+        when :confirm then handle_confirm
+        when :deny then handle_deny
+        when :show_model then show_model
+        when :quit
+          push_info_message("Shutting down...")
+          refresh_all
+          @running = false
         end
       end
 
@@ -646,17 +985,69 @@ module Homunculus
         push_user_message(message)
         refresh_all
 
-        @streaming_buf = nil
+        @messages_mutex.synchronize do
+          @streaming_buf = nil
+          @streaming_output_tokens_estimate = nil
+        end
         logger.info("TUI input", length: message.length, session_id: @session.id)
 
-        result = @agent_loop.run(message, @session)
-        @streaming_buf = nil
+        @activity_indicator.start("Thinking...")
+        agent_thread = Thread.new { @agent_loop.run(message, @session) }
+        wait_for_agent_with_scroll(agent_thread)
+        return unless @running
+
+        agent_thread.join
+        result = agent_thread.value
+        @messages_mutex.synchronize do
+          @streaming_buf = nil
+          @streaming_output_tokens_estimate = nil
+        end
         @scroll_offset = 0
         display_result(result)
       rescue StandardError => e
         logger.error("Error processing message", error: e.message)
         push_error_message("Error: #{e.message}")
         refresh_all
+      ensure
+        @activity_indicator&.stop
+        @messages_mutex.synchronize do
+          @streaming_buf = nil
+          @streaming_output_tokens_estimate = nil
+        end
+      end
+
+      # During agent execution: process only scroll keys and Ctrl+C; ignore other input.
+      def wait_for_agent_with_scroll(agent_thread)
+        while agent_thread.alive?
+          break unless @running
+
+          read_scroll_or_interrupt
+        end
+      end
+
+      # Returns true if caller should stop waiting (e.g. Ctrl+C).
+      def read_scroll_or_interrupt
+        $stdin.wait_readable(0.05)
+        char = $stdin.read_nonblock(1)
+        case char
+        when "\x03" # Ctrl+C
+          @running = false
+        when "\e"
+          consume_escape_sequence_scroll_only
+        end
+        # Ignore other keys (no input_buffer in scroll-only mode)
+      rescue IO::WaitReadable
+        nil
+      rescue EOFError
+        @running = false
+      end
+
+      def consume_escape_sequence_scroll_only
+        seq = read_escape_sequence
+        case seq
+        when "[A", "[1;2A", "[B", "[1;2B", "[5~", "[6~"
+          handle_scroll_keys(seq)
+        end
       end
 
       def handle_confirm
@@ -665,9 +1056,13 @@ module Homunculus
           refresh_all
           return
         end
-        push_info_message("Confirmed.")
+        tool_name = @session.pending_tool_call.name
         result = @agent_loop.confirm_tool(@session)
-        @streaming_buf = nil
+        push_info_message("✓ #{tool_name} completed")
+        @messages_mutex.synchronize do
+          @streaming_buf = nil
+          @streaming_output_tokens_estimate = nil
+        end
         @scroll_offset = 0
         display_result(result)
       rescue StandardError => e
@@ -681,9 +1076,12 @@ module Homunculus
           refresh_all
           return
         end
-        push_info_message("Denied.")
         result = @agent_loop.deny_tool(@session)
-        @streaming_buf = nil
+        push_info_message("Denied.")
+        @messages_mutex.synchronize do
+          @streaming_buf = nil
+          @streaming_output_tokens_estimate = nil
+        end
         @scroll_offset = 0
         display_result(result)
       rescue StandardError => e
@@ -694,14 +1092,23 @@ module Homunculus
       def display_result(result)
         case result.status
         when :completed
+          if result.respond_to?(:tier) && result.tier
+            @current_tier = result.tier
+            @current_model = result.model
+            @current_escalated_from = result.escalated_from
+          end
           # Non-streaming mode: push assistant message
           push_assistant_message(result.response) unless use_models_router?
         when :pending_confirmation
           tc = result.pending_tool_call
-          push_info_message(
-            "Tool call requires confirmation: #{tc.name} — args: #{tc.arguments.inspect}\n" \
-            "Type 'confirm' to proceed or 'deny' to cancel."
-          )
+          @messages_mutex.synchronize do
+            @messages << {
+              role: :tool_request,
+              tool_name: tc.name,
+              arguments: tc.arguments,
+              timestamp: Time.now
+            }
+          end
         when :error
           push_error_message(result.error.to_s)
         end
@@ -711,26 +1118,46 @@ module Homunculus
       # ── Message Queue ──────────────────────────────────────────────
 
       def push_user_message(text)
-        @messages << { role: :user, text: text.to_s }
+        @messages_mutex.synchronize { @messages << { role: :user, text: text.to_s, timestamp: Time.now } }
       end
 
       def push_assistant_message(text)
-        @messages << { role: :assistant, text: text.to_s }
+        @messages_mutex.synchronize { @messages << { role: :assistant, text: text.to_s, timestamp: Time.now } }
       end
 
       def push_info_message(text)
-        @messages << { role: :info, text: text.to_s }
+        @messages_mutex.synchronize { @messages << { role: :info, text: text.to_s, timestamp: Time.now } }
       end
 
       def push_error_message(text)
-        @messages << { role: :error, text: text.to_s }
+        friendly = text.to_s.start_with?("Error:") ? "Hmm, something went wrong: #{text.to_s.sub(/\AError:\s*/, '')}" : text.to_s
+        @messages_mutex.synchronize { @messages << { role: :error, text: friendly, timestamp: Time.now } }
+      end
+
+      def warm_greeting_text
+        hour = Time.now.hour
+        greeting = if hour >= 5 && hour < 12
+                     "Good morning! Ready to help with whatever you need today."
+                   elsif hour >= 12 && hour < 17
+                     "Good afternoon! What are we working on?"
+                   elsif hour >= 17 && hour < 22
+                     "Good evening! How can I help?"
+                   else
+                     "Burning the midnight oil? I'm here when you need me."
+                   end
+        "#{greeting} Type /help for commands, or just start chatting."
+      end
+
+      def session_context_line
+        tier = @current_tier && @current_model ? "#{@current_tier} (#{@current_model})" : (use_models_router? ? "router" : @provider_name.to_s)
+        "Session started · model: #{tier} · /help for commands"
       end
 
       # ── Help & Status Overlays ─────────────────────────────────────
 
       def show_help
         help_text = <<~HELP.strip
-          TUI Commands:
+          Here's what I can do:
             help       — This message
             status     — Session and config details
             confirm    — Approve a pending tool call
@@ -739,8 +1166,9 @@ module Homunculus
             quit / :q  — Exit
           Scroll:
             Arrow Up/Down or Page Up/Down to scroll history
+          Just type naturally — I understand plain language too.
         HELP
-        push_info_message(help_text)
+        @overlay_content = help_text.split("\n")
         refresh_all
       end
 
@@ -758,13 +1186,73 @@ module Homunculus
           Provider: #{@provider_name}
           Workspace:#{@config.agent.workspace_path}
         STATUS
-        push_info_message(status_text)
+        @overlay_content = status_text.split("\n")
         refresh_all
+      end
+
+      def show_model
+        tier_label = model_tier_label.sub(/\Amodel: /, "")
+        mc = use_models_router? ? nil : resolve_model_config
+        model_name = mc ? (mc.default_model || mc.model) : "router"
+        provider   = @provider_name
+
+        lines = [
+          "Model tier: #{tier_label}",
+          "Model:      #{model_name}",
+          "Provider:   #{provider}"
+        ]
+
+        tier_descriptions = load_tier_descriptions_from_models_toml
+        if tier_descriptions.any?
+          lines << ""
+          lines.concat(tier_descriptions)
+        end
+
+        @overlay_content = lines
+        refresh_all
+      end
+
+      # Returns array of "  tier_name — description" lines from config/models.toml, or [].
+      def load_tier_descriptions_from_models_toml
+        return [] unless File.file?(models_toml_path)
+
+        toml = TomlRB.load_file(models_toml_path)
+        tiers = toml["tiers"] || {}
+        tiers.map do |name, cfg|
+          desc = cfg.is_a?(Hash) ? (cfg["description"] || "") : ""
+          "  #{name} — #{desc}".strip
+        end.reject { |line| line.end_with?(" — ") }
       end
 
       # ── Shutdown ───────────────────────────────────────────────────
 
+      def format_int(n)
+        n.to_s.gsub(/(\d)(?=(\d{3})+(?!\d))/, '\\1,')
+      end
+
+      def print_session_summary
+        return unless @session && @session_start_time
+
+        elapsed = (Time.now - @session_start_time).to_i
+        duration_str = elapsed >= 3600 ? "#{elapsed / 3600}h #{(elapsed % 3600) / 60}m" : "#{elapsed / 60}m #{elapsed % 60}s"
+        turns = "#{@session.turn_count}/#{@config.agent.max_turns}"
+        in_t = @session.total_input_tokens
+        out_t = @session.total_output_tokens
+        token_str = "#{format_int(in_t)}↓ #{format_int(out_t)}↑"
+        tool_count = @messages_mutex.synchronize { @messages.count { |m| m[:role] == :tool_request } }
+        memory_line = (@memory_store && @session.turn_count.positive?) ? "Memory saved. " : ""
+        lines = [
+          "Session complete.",
+          "Duration: #{duration_str} · Turns: #{turns} · Tokens: #{token_str}",
+          (tool_count.positive? ? "Tools used: #{tool_count}. " : "") + "#{memory_line}See you next time!"
+        ]
+        $stdout.puts
+        $stdout.puts(lines.join("\n"))
+        $stdout.flush
+      end
+
       def shutdown
+        @activity_indicator&.stop
         @scheduler_manager&.stop
 
         return unless @session
@@ -784,11 +1272,6 @@ module Homunculus
 
       # ── ANSI / Rendering Helpers ───────────────────────────────────
 
-      def paint(text, *styles)
-        codes = styles.filter_map { |s| ANSI_CODES[s] }.join
-        "#{codes}#{text}#{ANSI_CODES[:reset]}"
-      end
-
       def move_to(col, row)
         $stdout.write("\e[#{row};#{col}H")
       end
@@ -797,13 +1280,8 @@ module Homunculus
         $stdout.write("\e[2K\e[1G")
       end
 
-      def horizontal_rule(char = "─")
+      def horizontal_rule(char = Theme::SEPARATOR_CHAR)
         char * term_width
-      end
-
-      # Compute visible length (strip ANSI escape sequences)
-      def visible_len(str)
-        str.gsub(/\e\[[0-9;]*[mGKHF]/, "").length
       end
     end
   end

--- a/lib/homunculus/interfaces/tui/activity_indicator.rb
+++ b/lib/homunculus/interfaces/tui/activity_indicator.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Homunculus
+  module Interfaces
+    class TUI
+      # Braille spinner for status bar. Runs in a dedicated thread, invokes
+      # redraw callback every ~100ms so the TUI can show frame + message.
+      class ActivityIndicator
+        FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+        FRAME_COUNT = 8
+        TICK_MS = 180
+        JOIN_TIMEOUT = 0.5
+
+        attr_reader :message
+
+        def initialize(redraw:)
+          @message     = ""
+          @running     = false
+          @frame_index = 0
+          @redraw      = redraw
+          @thread      = nil
+        end
+
+        def start(message)
+          @message = message.to_s
+          @running = true
+          @frame_index = 0
+          @thread = Thread.new { run_loop }
+        end
+
+        def update(message)
+          @message = message.to_s
+        end
+
+        def stop
+          @running = false
+          return unless @thread&.alive?
+
+          @thread.join(JOIN_TIMEOUT)
+          @thread = nil
+        end
+
+        def running?
+          @running
+        end
+
+        def frame_char
+          FRAMES[@frame_index % FRAME_COUNT]
+        end
+
+        private
+
+        def run_loop
+          while @running
+            @frame_index = (@frame_index + 1) % FRAME_COUNT
+            @redraw&.call
+            sleep(TICK_MS / 1000.0)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/homunculus/interfaces/tui/command_registry.rb
+++ b/lib/homunculus/interfaces/tui/command_registry.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Homunculus
+  module Interfaces
+    class TUI
+      # Registry of slash commands for the TUI. Used for matching, suggestions, and dispatch.
+      class CommandRegistry
+        COMMANDS = {
+          "/help" => { description: "Show available commands", handler: :show_help },
+          "/status" => { description: "Session and config details", handler: :show_status },
+          "/clear" => { description: "Clear chat history", handler: :clear },
+          "/confirm" => { description: "Approve pending tool call", handler: :confirm },
+          "/deny" => { description: "Reject pending tool call", handler: :deny },
+          "/model" => { description: "Show current model tier and routing info", handler: :show_model },
+          "/quit" => { description: "Exit", handler: :quit },
+          "/exit" => { description: "Exit (alias)", handler: :quit },
+          "/q" => { description: "Exit (alias)", handler: :quit }
+        }.freeze
+
+        # Returns the command key if +input+ is exactly a command or command with trailing space; otherwise nil.
+        # +input+ is assumed to be user input (may be stripped by caller).
+        def match(input)
+          return nil if input.nil? || !input.to_s.start_with?("/")
+
+          key = input.to_s.strip.split(/\s/, 2).first
+          COMMANDS.key?(key) ? key : nil
+        end
+
+        # Returns an array of command strings that start with +partial+ (e.g. "/he" => ["/help"]).
+        def suggestions(partial)
+          return [] if partial.nil? || !partial.to_s.start_with?("/")
+
+          COMMANDS.keys.select { |cmd| cmd.start_with?(partial.to_s) }.sort
+        end
+
+        # Returns an array of { command:, description: } for suggestions that start with +partial+.
+        def suggestions_with_descriptions(partial)
+          return [] if partial.nil? || !partial.to_s.start_with?("/")
+
+          COMMANDS.keys
+            .select { |cmd| cmd.start_with?(partial.to_s) }
+            .sort
+            .map { |cmd| { command: cmd, description: COMMANDS[cmd][:description] } }
+        end
+      end
+    end
+  end
+end

--- a/lib/homunculus/interfaces/tui/input_buffer.rb
+++ b/lib/homunculus/interfaces/tui/input_buffer.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Homunculus
+  module Interfaces
+    class TUI
+      # Cursor-aware line buffer for TUI input. Cursor is always in 0..buf.length.
+      class InputBuffer
+        attr_reader :cursor
+
+        def initialize
+          @buf    = +""
+          @cursor = 0
+        end
+
+        def insert(char)
+          return if char.nil? || char.to_s.empty?
+
+          c = char.to_s
+          @buf.insert(@cursor, c)
+          @cursor = clamp_cursor(@cursor + c.length)
+        end
+
+        def backspace
+          return if @cursor <= 0
+
+          @buf.slice!(@cursor - 1)
+          @cursor = clamp_cursor(@cursor - 1)
+        end
+
+        def delete
+          return if @cursor >= @buf.length
+
+          @buf.slice!(@cursor)
+        end
+
+        def move_left
+          @cursor = clamp_cursor(@cursor - 1)
+        end
+
+        def move_right
+          @cursor = clamp_cursor(@cursor + 1)
+        end
+
+        def move_home
+          @cursor = 0
+        end
+
+        def move_end
+          @cursor = @buf.length
+        end
+
+        def move_word_left
+          return move_home if @cursor <= 0
+
+          # Skip spaces left of cursor, then skip word chars
+          i = @cursor - 1
+          i -= 1 while i >= 0 && @buf[i] =~ /\s/
+          i -= 1 while i >= 0 && @buf[i] !~ /\s/
+          @cursor = i.negative? ? 0 : i + 1
+        end
+
+        def move_word_right
+          return move_end if @cursor >= @buf.length
+
+          # Skip spaces, then skip word chars
+          i = @cursor
+          i += 1 while i < @buf.length && @buf[i] =~ /\s/
+          i += 1 while i < @buf.length && @buf[i] !~ /\s/
+          @cursor = i
+        end
+
+        # Delete from cursor back to last space or start (Ctrl+W).
+        def delete_word_backward
+          return if @cursor <= 0
+
+          start = @cursor - 1
+          start -= 1 while start >= 0 && @buf[start] =~ /\s/
+          start -= 1 while start >= 0 && @buf[start] !~ /\s/
+          start += 1
+          start = 0 if start.negative?
+          @buf.slice!(start...@cursor)
+          @cursor = start
+        end
+
+        def to_s
+          @buf.to_s
+        end
+
+        def clear
+          @buf = +""
+          @cursor = 0
+        end
+
+        private
+
+        def clamp_cursor(pos)
+          pos.clamp(0, @buf.length)
+        end
+      end
+    end
+  end
+end

--- a/lib/homunculus/interfaces/tui/message_renderer.rb
+++ b/lib/homunculus/interfaces/tui/message_renderer.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+require_relative "theme"
+
+module Homunculus
+  module Interfaces
+    class TUI
+      # Renders chat message hashes into styled terminal lines. Supports markdown
+      # (bold, italic, code, lists, headings) for assistant messages only.
+      class MessageRenderer
+        include TUI::Theme
+
+        def initialize(width:, agent_name: TUI::AGENT_NAME)
+          @width = width
+          @agent_name = agent_name
+        end
+
+        def render(msg)
+          role = msg[:role]
+          return render_tool_card(msg) if role == :tool_request
+
+          text = msg[:text].to_s
+          label = role_label(role)
+          color = role_style(role)
+          timestamp_plain = msg[:timestamp] ? msg[:timestamp].strftime("[%H:%M] ") : ""
+          prefix_plain = "#{timestamp_plain}#{role_indicator(role)} #{label}: "
+          indent = " " * Theme.visible_len(prefix_plain)
+
+          if role == :assistant && !text.empty?
+            render_with_markdown(text, prefix_plain, indent, color)
+          else
+            render_plain(text, prefix_plain, indent, color)
+          end
+        end
+
+        private
+
+        def role_label(role)
+          case role
+          when :user      then "You"
+          when :assistant then @agent_name
+          when :system    then "System"
+          when :error     then "Error"
+          when :tool_request then "Tool"
+          else                 role.to_s.capitalize
+          end
+        end
+
+        def role_indicator(role)
+          case role
+          when :user      then Theme::ROLE_USER
+          when :assistant then Theme::ROLE_ASSISTANT
+          when :info      then Theme::ROLE_INFO
+          when :error     then Theme::ROLE_ERROR
+          else                 Theme::ROLE_INFO
+          end
+        end
+
+        def role_style(role)
+          case role
+          when :user      then :user
+          when :assistant then :assistant
+          when :system    then :accent
+          when :error     then :error
+          when :info      then :info
+          when :tool_request then :accent
+          else                 :muted
+          end
+        end
+
+        def render_tool_card(msg)
+          name = msg[:tool_name].to_s
+          args = msg[:arguments] || {}
+          w = @width
+          border_char = "─"
+          inner_w = [w - 4, 10].max
+          top = "┌─ Tool Request #{border_char * [w - 18, 1].max}┐"[0, w]
+          bottom = "└#{border_char * (w - 2)}┘"
+          lines = [
+            Theme.paint(top, :accent),
+            Theme.paint("│  #{name.to_s[0, inner_w].ljust(inner_w)}│", :accent)
+          ]
+          args.each do |k, v|
+            arg_line = "#{k}: #{v.inspect}"
+            arg_line = arg_line[0, inner_w] if arg_line.length > inner_w
+            lines << Theme.paint("│  #{arg_line.ljust(inner_w)}│", :accent)
+          end
+          lines << Theme.paint("│#{' ' * (w - 2)}│", :accent)
+          hint1 = "  ◈ Requires confirmation"
+          hint2 = "  Type /confirm or /deny"
+          lines << Theme.paint("│#{hint1.to_s[0, w - 2].ljust(w - 2)}│", :accent)
+          lines << Theme.paint("│#{hint2.to_s[0, w - 2].ljust(w - 2)}│", :accent)
+          lines << Theme.paint(bottom, :accent)
+          lines
+        end
+
+        def render_plain(text, prefix_plain, indent, color)
+          lines = []
+          text.split("\n").each_with_index do |para, para_idx|
+            words = para.split
+            current_line = para_idx.zero? ? prefix_plain : indent
+            words.each do |word|
+              if Theme.visible_len(current_line) + word.length + 1 > @width
+                lines << paint_role_line(current_line, color, para_idx.zero? && lines.empty?)
+                current_line = indent + word
+              else
+                current_line += (current_line == indent || current_line == prefix_plain ? "" : " ") + word
+              end
+            end
+            lines << paint_role_line(current_line, color, para_idx.zero? && lines.empty?) unless current_line.strip.empty?
+          end
+          lines.empty? ? [paint_role_line(prefix_plain, color, true)] : lines
+        end
+
+        def render_with_markdown(text, prefix_plain, indent, color)
+          segments = split_code_blocks(text)
+          out = []
+          first_line = true
+          prefix_len = Theme.visible_len(prefix_plain)
+          indent_len = Theme.visible_len(indent)
+
+          segments.each do |seg|
+            if seg[:type] == :code
+              block_lines = seg[:content].strip.split("\n")
+              block_lines.shift if block_lines.first.to_s.match(/\A\w+\s*\z/)
+              block_lines.each do |line|
+                styled = Theme.paint("  #{line}", :warm_highlight)
+                out << (first_line ? paint_role_line(prefix_plain, color, true).sub(/: \z/, ": ") + styled : indent + styled)
+                first_line = false
+              end
+            else
+              expanded = apply_inline_markdown(seg[:content])
+              wrapped = wrap_styled_text(expanded, first_line ? prefix_len : indent_len)
+              wrapped.each_with_index do |line_plain, i|
+                line_with_prefix = first_line && i.zero? ? prefix_plain + line_plain : indent + line_plain
+                out << paint_role_line(line_with_prefix, color, first_line && i.zero?)
+                first_line = false
+              end
+            end
+          end
+
+          out = [paint_role_line(prefix_plain, color, true)] if out.empty?
+          out
+        end
+
+        def split_code_blocks(text)
+          result = []
+          rest = text
+          until rest.empty?
+            idx = rest.index("```")
+            unless idx
+              result << { type: :text, content: rest }
+              break
+            end
+            result << { type: :text, content: rest[0...idx] } if idx.positive?
+            rest = rest[(idx + 3)..] || ""
+            end_idx = rest.index("```")
+            unless end_idx
+              result << { type: :text, content: "```" + rest }
+              break
+            end
+            result << { type: :code, content: rest[0...end_idx] }
+            rest = rest[(end_idx + 3)..] || ""
+          end
+          result
+        end
+
+        def apply_inline_markdown(segment)
+          # Process by lines to handle lists and headings
+          segment.split("\n").map do |line|
+            line = apply_heading(line)
+            line = apply_list_line(line)
+            apply_inline_formatting(line)
+          end.join("\n")
+        end
+
+        def apply_heading(line)
+          return line unless line.match(/\A#+\s+/)
+
+          m = line.match(/\A(#+)\s+(.*)/)
+          return line unless m
+
+          rest = m[2]
+          Theme.paint(rest, :bold)
+        end
+
+        def apply_list_line(line)
+          if line.match(/\A\s*[-*]\s+/)
+            line = line.sub(/\A(\s*)[-*](\s+)/, "\\1#{Theme::BULLET_CHAR}\\2")
+          end
+          line
+        end
+
+        def apply_inline_formatting(line)
+          # Inline code: `...` -> warm_highlight (non-greedy)
+          line = line.gsub(/`([^`]+)`/) { Theme.paint($1, :warm_highlight) }
+          # Bold: **x** or __x__
+          line = line.gsub(/\*\*(.+?)\*\*/) { Theme.paint($1, :bold) }
+          line = line.gsub(/__(.+?)__/) { Theme.paint($1, :bold) }
+          # Italic: *x* or _x_ (single; avoid breaking **)
+          line = line.gsub(/(?<!\*)\*([^*]+)\*(?!\*)/) { Theme.paint($1, :italic) }
+          line = line.gsub(/(?<!_)_([^_]+)_(?!_)/) { Theme.paint($1, :italic) }
+          line
+        end
+
+        def wrap_styled_text(styled_str, indent_len)
+          words = styled_str.split(/(\s+)/)
+          lines = []
+          current = +""
+          current_len = 0
+          max_len = @width - indent_len
+
+          words.each do |w|
+            wlen = Theme.visible_len(w)
+            if current_len + wlen > max_len && !current.empty?
+              lines << current
+              current = w
+              current_len = wlen
+            else
+              current << w
+              current_len += wlen
+            end
+          end
+          lines << current unless current.empty?
+          lines
+        end
+
+        def paint_role_line(line, color, is_label_line)
+          return line if line.strip.empty?
+
+          if is_label_line
+            ts_match = line.match(/\A(\[\d{2}:\d{2}\] )/)
+            if ts_match
+              ts_prefix = ts_match[1]
+              return Theme.paint(ts_prefix, :muted) + paint_role_line(line[ts_prefix.length..], color, true)
+            end
+            label_end = line.index(": ")
+            if label_end
+              label_part = line[0..(label_end + 1)]
+              rest_part = line[(label_end + 2)..]
+              return Theme.paint(label_part, color, :bold) + (rest_part.to_s.include?("\e[") ? rest_part.to_s : Theme.paint(rest_part.to_s, :reset))
+            end
+            Theme.paint(line, color)
+          else
+            line.include?("\e[") ? line : Theme.paint(line, :reset)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/homunculus/interfaces/tui/theme.rb
+++ b/lib/homunculus/interfaces/tui/theme.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Homunculus
+  module Interfaces
+    class TUI
+      # Warm color palette and decorative constants for the TUI.
+      # Uses 256-color ANSI when available; falls back to 16-color for basic terminals.
+      module Theme
+        # 256-color palette (foreground: \e[38;5;Nm, background: \e[48;5;Nm)
+        C256 = {
+          user: "\e[38;5;75m",        # soft sky blue
+          assistant: "\e[38;5;108m", # warm sage green
+          info: "\e[38;5;183m",      # lavender mist
+          error: "\e[38;5;174m",     # soft coral
+          accent: "\e[38;5;214m",    # warm amber
+          muted: "\e[38;5;245m",     # gentle gray
+          warm_highlight: "\e[38;5;223m", # warm sand (e.g. inline code)
+          local_tier: "\e[32m",      # green (16-color)
+          cloud_tier: "\e[33m",      # yellow (16-color)
+          escalated_tier: "\e[41m"   # bg red (16-color)
+        }.freeze
+
+        # 16-color fallback (same semantic keys)
+        C16 = {
+          user: "\e[36m",
+          assistant: "\e[32m",
+          info: "\e[2m",
+          error: "\e[31m",
+          accent: "\e[33m",
+          muted: "\e[2m",
+          warm_highlight: "\e[33m",
+          local_tier: "\e[32m",
+          cloud_tier: "\e[33m",
+          escalated_tier: "\e[41m"
+        }.freeze
+
+        # Style modifiers (same in 16 and 256)
+        RESET = "\e[0m"
+        BOLD = "\e[1m"
+        DIM = "\e[2m"
+        ITALIC = "\e[3m"
+        UNDERLINE = "\e[4m"
+        REVERSE = "\e[7m"
+
+        # Decorative characters
+        SEPARATOR_CHAR = "─"
+        HEADER_TOP_CHAR = "━"
+        HEADER_BOTTOM_CHAR = "·"
+        HEADER_TITLE_FLANK = "··"
+        BULLET_CHAR = "•"
+        PROMPT_CHAR = "›"
+        TURN_SEPARATOR = "· · ·"
+        STATUS_SEP = " · "
+        ROLE_USER = "▸"
+        ROLE_ASSISTANT = "◆"
+        ROLE_INFO = "○"
+        ROLE_ERROR = "✖"
+
+        class << self
+          def use_256_colors?
+            term = ENV["TERM"].to_s
+            colorterm = ENV["COLORTERM"].to_s
+            term.include?("256") || term.include?("256color") || colorterm == "truecolor" || colorterm == "24bit"
+          end
+
+          def palette
+            use_256_colors? ? C256 : C16
+          end
+
+          def paint(text, *styles)
+            codes = styles.filter_map { |s| ansi_for(s) }.join
+            "#{codes}#{text}#{RESET}"
+          end
+
+          def ansi_for(style)
+            case style
+            when :reset then RESET
+            when :bold then BOLD
+            when :dim then DIM
+            when :italic then ITALIC
+            when :underline then UNDERLINE
+            when :reverse then REVERSE
+            when :user, :user_label then palette[:user]
+            when :assistant, :assistant_label then palette[:assistant]
+            when :info, :info_label then palette[:info]
+            when :error, :error_label then palette[:error]
+            when :accent then palette[:accent]
+            when :muted then palette[:muted]
+            when :warm_highlight then palette[:warm_highlight]
+            when :green, :local_tier then palette[:local_tier]
+            when :yellow, :cloud_tier then palette[:cloud_tier]
+            when :bg_red, :escalated_tier then palette[:escalated_tier]
+            when :bright_blue then palette[:accent]
+            when :cyan then palette[:user]
+            when :white then RESET
+            else nil
+            end
+          end
+
+          def visible_len(str)
+            str.to_s.gsub(/\e\[[0-9;]*[mGKHF]/, "").length
+          end
+        end
+
+        # Instance methods for TUI when including Theme
+        def paint(text, *styles)
+          Theme.paint(text, *styles)
+        end
+
+        def visible_len(str)
+          Theme.visible_len(str)
+        end
+      end
+    end
+  end
+end

--- a/spec/interfaces/tui/activity_indicator_spec.rb
+++ b/spec/interfaces/tui/activity_indicator_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/homunculus/interfaces/tui"
+
+RSpec.describe Homunculus::Interfaces::TUI::ActivityIndicator do
+  subject(:indicator) { described_class.new(redraw:) }
+
+  # Callable invoked from background thread; plain double avoids lifecycle errors when thread outlives example.
+  let(:redraw) { double("redraw") } # rubocop:disable RSpec/VerifiedDoubles
+
+  before do
+    allow(redraw).to receive(:call)
+  end
+
+  describe "#start" do
+    it "sets message and running to true" do
+      indicator.start("Thinking...")
+      expect(indicator.message).to eq("Thinking...")
+      expect(indicator.running?).to be true
+    end
+
+    it "starts a thread that invokes redraw periodically" do
+      indicator.start("Working")
+      sleep(0.25)
+      indicator.stop
+      sleep(0.15) # allow spinner thread to exit before asserting (avoids OutsideOfExampleError)
+      expect(redraw).to have_received(:call).at_least(:twice)
+    end
+  end
+
+  describe "#update" do
+    it "changes the message without stopping" do
+      indicator.start("Thinking...")
+      indicator.update("Running tool: echo...")
+      expect(indicator.message).to eq("Running tool: echo...")
+      expect(indicator.running?).to be true
+      indicator.stop
+    end
+  end
+
+  describe "#stop" do
+    it "sets running to false and joins the thread" do
+      indicator.start("Thinking...")
+      expect(indicator.running?).to be true
+      indicator.stop
+      expect(indicator.running?).to be false
+    end
+
+    it "is idempotent" do
+      indicator.start("x")
+      indicator.stop
+      expect { indicator.stop }.not_to raise_error
+    end
+
+    it "allows the spinner thread to exit (no orphaned thread)" do
+      indicator.start("x")
+      thread_before = Thread.list.count
+      indicator.stop
+      sleep(0.1)
+      # Spinner thread should be gone; allow for test framework threads
+      expect(Thread.list.count).to be <= thread_before + 1
+    end
+  end
+
+  describe "#frame_char" do
+    it "returns a character from the braille spinner set" do
+      frames = described_class::FRAMES[0, described_class::FRAME_COUNT]
+      indicator.start("x")
+      chars = 10.times.map do
+        c = indicator.frame_char
+        sleep(0.02)
+        c
+      end
+      indicator.stop
+      chars.each { |c| expect(frames).to include(c) }
+    end
+  end
+end

--- a/spec/interfaces/tui/command_registry_spec.rb
+++ b/spec/interfaces/tui/command_registry_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/homunculus/interfaces/tui"
+require_relative "../../../lib/homunculus/interfaces/tui/command_registry"
+
+RSpec.describe Homunculus::Interfaces::TUI::CommandRegistry do
+  subject(:registry) { described_class.new }
+
+  describe "#match" do
+    it "returns /help for exact /help" do
+      expect(registry.match("/help")).to eq("/help")
+    end
+
+    it "returns /help for /help with trailing space" do
+      expect(registry.match("/help ")).to eq("/help")
+    end
+
+    it "returns nil for bare help (no slash)" do
+      expect(registry.match("help")).to be_nil
+    end
+
+    it "returns /quit for /quit and /exit and /q" do
+      expect(registry.match("/quit")).to eq("/quit")
+      expect(registry.match("/exit")).to eq("/exit")
+      expect(registry.match("/q")).to eq("/q")
+    end
+
+    it "returns nil for unknown slash command" do
+      expect(registry.match("/unknown")).to be_nil
+      expect(registry.match("/")).to be_nil
+    end
+
+    it "returns nil for nil or non-slash input" do
+      expect(registry.match(nil)).to be_nil
+      expect(registry.match("")).to be_nil
+      expect(registry.match("  hello  ")).to be_nil
+    end
+  end
+
+  describe "#suggestions" do
+    it "returns commands starting with partial" do
+      expect(registry.suggestions("/he")).to include("/help")
+      expect(registry.suggestions("/he")).to eq(["/help"])
+    end
+
+    it "returns all slash commands for partial /" do
+      all = registry.suggestions("/")
+      expect(all).to include("/help", "/status", "/clear", "/confirm", "/deny", "/model", "/quit", "/exit", "/q")
+      expect(all).to eq(all.sort)
+    end
+
+    it "returns /q and /quit for /q" do
+      expect(registry.suggestions("/q")).to contain_exactly("/q", "/quit")
+    end
+
+    it "returns empty for non-slash partial" do
+      expect(registry.suggestions("help")).to eq([])
+      expect(registry.suggestions("")).to eq([])
+      expect(registry.suggestions(nil)).to eq([])
+    end
+  end
+
+  describe "#suggestions_with_descriptions" do
+    it "returns command and description hashes for partial" do
+      list = registry.suggestions_with_descriptions("/he")
+      expect(list).to contain_exactly({ command: "/help", description: "Show available commands" })
+    end
+
+    it "returns empty for non-slash partial" do
+      expect(registry.suggestions_with_descriptions("help")).to eq([])
+      expect(registry.suggestions_with_descriptions(nil)).to eq([])
+    end
+  end
+end

--- a/spec/interfaces/tui/input_buffer_spec.rb
+++ b/spec/interfaces/tui/input_buffer_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/homunculus/interfaces/tui"
+require_relative "../../../lib/homunculus/interfaces/tui/input_buffer"
+
+RSpec.describe Homunculus::Interfaces::TUI::InputBuffer do
+  subject(:buffer) { described_class.new }
+
+  describe "#to_s and #clear" do
+    it "starts empty" do
+      expect(buffer.to_s).to eq("")
+      expect(buffer.cursor).to eq(0)
+    end
+
+    it "clear resets buffer and cursor" do
+      buffer.insert("a")
+      buffer.insert("b")
+      buffer.clear
+      expect(buffer.to_s).to eq("")
+      expect(buffer.cursor).to eq(0)
+    end
+  end
+
+  describe "#insert" do
+    it "inserts at cursor and advances cursor" do
+      buffer.insert("a")
+      expect(buffer.to_s).to eq("a")
+      expect(buffer.cursor).to eq(1)
+      buffer.insert("b")
+      expect(buffer.to_s).to eq("ab")
+      expect(buffer.cursor).to eq(2)
+    end
+
+    it "inserts in the middle when cursor is not at end" do
+      buffer.insert("a")
+      buffer.insert("b")
+      buffer.move_left
+      buffer.insert("x")
+      expect(buffer.to_s).to eq("axb")
+      expect(buffer.cursor).to eq(2)
+    end
+
+    it "ignores nil and empty string" do
+      buffer.insert("a")
+      buffer.insert(nil)
+      buffer.insert("")
+      expect(buffer.to_s).to eq("a")
+    end
+  end
+
+  describe "#backspace" do
+    it "deletes char before cursor and moves cursor left" do
+      buffer.insert("a")
+      buffer.insert("b")
+      buffer.backspace
+      expect(buffer.to_s).to eq("a")
+      expect(buffer.cursor).to eq(1)
+    end
+
+    it "deletes at cursor position when cursor is in middle" do
+      buffer.insert("a")
+      buffer.insert("b")
+      buffer.insert("c")
+      buffer.move_left
+      buffer.move_left
+      buffer.backspace
+      expect(buffer.to_s).to eq("bc")
+      expect(buffer.cursor).to eq(0)
+    end
+
+    it "does nothing at cursor 0" do
+      buffer.backspace
+      expect(buffer.to_s).to eq("")
+      buffer.insert("a")
+      buffer.move_home
+      buffer.backspace
+      expect(buffer.to_s).to eq("a")
+      expect(buffer.cursor).to eq(0)
+    end
+  end
+
+  describe "#delete" do
+    it "deletes char at cursor" do
+      buffer.insert("a")
+      buffer.insert("b")
+      buffer.move_left
+      buffer.delete
+      expect(buffer.to_s).to eq("a")
+      expect(buffer.cursor).to eq(1)
+    end
+
+    it "does nothing when cursor at end" do
+      buffer.insert("a")
+      buffer.delete
+      expect(buffer.to_s).to eq("a")
+    end
+
+    it "does nothing when empty" do
+      buffer.delete
+      expect(buffer.to_s).to eq("")
+    end
+  end
+
+  describe "#move_left and #move_right" do
+    it "move_left decrements cursor and clamps at 0" do
+      buffer.insert("ab")
+      buffer.move_left
+      expect(buffer.cursor).to eq(1)
+      buffer.move_left
+      expect(buffer.cursor).to eq(0)
+      buffer.move_left
+      expect(buffer.cursor).to eq(0)
+    end
+
+    it "move_right increments cursor and clamps at length" do
+      buffer.insert("ab")
+      buffer.move_right
+      expect(buffer.cursor).to eq(2)
+      buffer.move_right
+      expect(buffer.cursor).to eq(2)
+      buffer.move_left
+      buffer.move_left
+      buffer.move_left
+      expect(buffer.cursor).to eq(0)
+    end
+  end
+
+  describe "#move_home and #move_end" do
+    it "move_home sets cursor to 0" do
+      buffer.insert("hello")
+      buffer.move_home
+      expect(buffer.cursor).to eq(0)
+    end
+
+    it "move_end sets cursor to buffer length" do
+      buffer.insert("hello")
+      buffer.move_end
+      expect(buffer.cursor).to eq(5)
+    end
+  end
+
+  describe "#move_word_left and #move_word_right" do
+    it "move_word_left jumps to start of current or previous word" do
+      buffer.insert("foo bar baz")
+      buffer.move_end
+      buffer.move_word_left
+      expect(buffer.cursor).to eq(8)
+      buffer.move_word_left
+      expect(buffer.cursor).to eq(4)
+      buffer.move_word_left
+      expect(buffer.cursor).to eq(0)
+      buffer.move_word_left
+      expect(buffer.cursor).to eq(0)
+    end
+
+    it "move_word_right jumps to end of current word or start of next" do
+      buffer.insert("foo bar baz")
+      buffer.move_home
+      buffer.move_word_right
+      expect(buffer.cursor).to eq(3)
+      buffer.move_word_right
+      expect(buffer.cursor).to eq(7)
+      buffer.move_word_right
+      expect(buffer.cursor).to eq(11)
+      buffer.move_word_right
+      expect(buffer.cursor).to eq(11)
+    end
+
+    it "move_word_left from middle of word goes to start of word" do
+      buffer.insert("foo")
+      buffer.move_right
+      buffer.move_word_left
+      expect(buffer.cursor).to eq(0)
+    end
+
+    it "move_word_right at end does nothing" do
+      buffer.insert("foo")
+      buffer.move_end
+      buffer.move_word_right
+      expect(buffer.cursor).to eq(3)
+    end
+  end
+
+  describe "#delete_word_backward" do
+    it "deletes word before cursor" do
+      buffer.insert("foo bar baz")
+      buffer.move_end
+      buffer.delete_word_backward
+      expect(buffer.to_s).to eq("foo bar ")
+      expect(buffer.cursor).to eq(8)
+    end
+
+    it "deletes from cursor back to start when no space before" do
+      buffer.insert("foo")
+      buffer.move_end
+      buffer.delete_word_backward
+      expect(buffer.to_s).to eq("")
+      expect(buffer.cursor).to eq(0)
+    end
+
+    it "does nothing when cursor at 0" do
+      buffer.insert("foo")
+      buffer.move_home
+      buffer.delete_word_backward
+      expect(buffer.to_s).to eq("foo")
+    end
+  end
+
+  describe "cursor boundaries" do
+    it "cursor always in 0..buf.length after operations" do
+      buffer.insert("x")
+      expect(buffer.cursor).to be_between(0, buffer.to_s.length)
+      buffer.move_right
+      buffer.move_right
+      expect(buffer.cursor).to eq(1)
+      buffer.move_left
+      buffer.move_left
+      expect(buffer.cursor).to eq(0)
+    end
+  end
+end

--- a/spec/interfaces/tui/message_renderer_spec.rb
+++ b/spec/interfaces/tui/message_renderer_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/homunculus/interfaces/tui"
+
+RSpec.describe Homunculus::Interfaces::TUI::MessageRenderer do
+  let(:width) { 80 }
+  let(:agent_name) { "Homunculus" }
+  subject(:renderer) { described_class.new(width:, agent_name:) }
+
+  describe "#render" do
+    it "renders a user message with You prefix" do
+      msg = { role: :user, text: "Hello world", timestamp: nil }
+      lines = renderer.render(msg)
+      joined = lines.join
+      expect(joined).to include("You")
+      expect(joined).to include("Hello world")
+    end
+
+    it "renders an assistant message with agent name prefix" do
+      msg = { role: :assistant, text: "I can help", timestamp: nil }
+      lines = renderer.render(msg)
+      joined = lines.join
+      expect(joined).to include(agent_name)
+      expect(joined).to include("I can help")
+    end
+
+    it "wraps long lines at width" do
+      long = "word " * 30
+      msg = { role: :user, text: long.strip, timestamp: nil }
+      lines = renderer.render(msg)
+      raw = lines.map { |l| l.gsub(/\e\[[0-9;]*[mGKHF]/, "") }
+      raw.each { |line| expect(line.length).to be <= width + 2 }
+    end
+
+    it "includes timestamp when present" do
+      t = Time.now
+      msg = { role: :user, text: "hi", timestamp: t }
+      lines = renderer.render(msg)
+      expect(lines.join).to include(t.strftime("[%H:%M]"))
+    end
+
+    it "renders bold in assistant messages" do
+      msg = { role: :assistant, text: "This is **important** text", timestamp: nil }
+      lines = renderer.render(msg)
+      expect(lines.join).to include("\e[1m")
+      expect(lines.join).to include("important")
+    end
+
+    it "renders inline code in assistant messages" do
+      msg = { role: :assistant, text: "Run `ls -la` to list", timestamp: nil }
+      lines = renderer.render(msg)
+      expect(lines.join).to include("ls -la")
+    end
+
+    it "does not apply markdown to user messages" do
+      msg = { role: :user, text: "Use **bold** here", timestamp: nil }
+      lines = renderer.render(msg)
+      joined = lines.join
+      # Literal **bold** must appear (not converted to ANSI bold)
+      expect(joined).to include("**bold**")
+    end
+
+    it "renders empty assistant message as label only" do
+      msg = { role: :assistant, text: "", timestamp: nil }
+      lines = renderer.render(msg)
+      expect(lines.size).to eq(1)
+      expect(lines.first).to include(agent_name)
+    end
+  end
+end

--- a/spec/interfaces/tui/theme_spec.rb
+++ b/spec/interfaces/tui/theme_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "../../../lib/homunculus/interfaces/tui/theme"
+
+RSpec.describe Homunculus::Interfaces::TUI::Theme do
+  describe ".use_256_colors?" do
+    it "returns true when TERM includes 256" do
+      allow(ENV).to receive(:[]).with("TERM").and_return("xterm-256color")
+      allow(ENV).to receive(:[]).with("COLORTERM").and_return(nil)
+      expect(described_class.use_256_colors?).to be true
+    end
+
+    it "returns false when TERM is basic" do
+      allow(ENV).to receive(:[]).with("TERM").and_return("xterm")
+      allow(ENV).to receive(:[]).with("COLORTERM").and_return(nil)
+      expect(described_class.use_256_colors?).to be false
+    end
+  end
+
+  describe ".palette" do
+    it "returns a hash with semantic color keys" do
+      palette = described_class.palette
+      expect(palette).to include(:user, :assistant, :info, :error, :muted, :accent)
+      expect(palette[:user]).to start_with("\e[")
+      expect(palette[:assistant]).to start_with("\e[")
+    end
+  end
+
+  describe ".paint" do
+    it "wraps text with ANSI codes and reset" do
+      result = described_class.paint("hello", :bold)
+      expect(result).to include("\e[1m")
+      expect(result).to include("hello")
+      expect(result).to include("\e[0m")
+    end
+
+    it "applies multiple styles" do
+      result = described_class.paint("x", :bold, :user)
+      expect(result).to include("\e[1m")
+      expect(result).to include("x")
+    end
+
+    it "handles unknown style by ignoring it" do
+      result = described_class.paint("hi", :unknown_style)
+      expect(result).to include("hi")
+      expect(result).to include("\e[0m")
+    end
+
+    it "maps semantic names :user_label and :dim" do
+      expect(described_class.paint("a", :user_label)).to include("a")
+      expect(described_class.paint("b", :muted)).to include("b")
+    end
+  end
+
+  describe ".visible_len" do
+    it "strips ANSI and returns character count" do
+      colored = described_class.paint("hello", :cyan)
+      expect(described_class.visible_len(colored)).to eq(5)
+    end
+
+    it "returns 0 for empty string" do
+      expect(described_class.visible_len("")).to eq(0)
+    end
+  end
+
+  describe "constants" do
+    it "defines separator and header chars" do
+      expect(described_class::SEPARATOR_CHAR).to be_a(String)
+      expect(described_class::HEADER_TOP_CHAR).to be_a(String)
+      expect(described_class::HEADER_BOTTOM_CHAR).to be_a(String)
+      expect(described_class::PROMPT_CHAR).to be_a(String)
+      expect(described_class::BULLET_CHAR).to be_a(String)
+    end
+
+    it "defines role indicator chars" do
+      expect(described_class::ROLE_USER).to be_a(String)
+      expect(described_class::ROLE_ASSISTANT).to be_a(String)
+      expect(described_class::ROLE_INFO).to be_a(String)
+      expect(described_class::ROLE_ERROR).to be_a(String)
+    end
+  end
+
+  describe "instance methods (for TUI include)" do
+    let(:tui_class) do
+      Class.new do
+        include Homunculus::Interfaces::TUI::Theme
+      end
+    end
+
+    it "paint delegates to Theme.paint" do
+      obj = tui_class.new
+      result = obj.paint("test", :bold)
+      expect(result).to include("test")
+      expect(result).to include("\e[0m")
+    end
+
+    it "visible_len delegates to Theme.visible_len" do
+      obj = tui_class.new
+      expect(obj.visible_len("hello")).to eq(5)
+      colored = described_class.paint("hello", :user)
+      expect(obj.visible_len(colored)).to eq(5)
+    end
+  end
+end

--- a/spec/interfaces/tui_spec.rb
+++ b/spec/interfaces/tui_spec.rb
@@ -65,14 +65,30 @@ RSpec.describe Homunculus::Interfaces::TUI do
       expect(tui.instance_variable_get(:@messages)).to be_empty
     end
 
+    it "starts with no overlay" do
+      tui = described_class.new(config:)
+      expect(tui.instance_variable_get(:@overlay_content)).to be_nil
+    end
+
     it "starts with scroll offset 0" do
       tui = described_class.new(config:)
       expect(tui.instance_variable_get(:@scroll_offset)).to eq(0)
     end
 
+    it "initializes with a messages_mutex for thread-safe message buffer" do
+      tui = described_class.new(config:)
+      expect(tui.instance_variable_get(:@messages_mutex)).to be_a(Mutex)
+    end
+
     it "does not initialize scheduler when disabled" do
       tui = described_class.new(config:)
       expect(tui.instance_variable_get(:@scheduler_manager)).to be_nil
+    end
+
+    it "initializes with an activity indicator (Story 3)" do
+      tui = described_class.new(config:)
+      indicator = tui.instance_variable_get(:@activity_indicator)
+      expect(indicator).to be_a(described_class::ActivityIndicator)
     end
   end
 
@@ -170,47 +186,55 @@ RSpec.describe Homunculus::Interfaces::TUI do
   describe "message queue methods" do
     subject(:tui) { described_class.new(config:) }
 
-    it "push_user_message adds a user message" do
+    it "push_user_message adds a user message with timestamp" do
       tui.send(:push_user_message, "Hello!")
       msgs = tui.instance_variable_get(:@messages)
       expect(msgs.last).to include(role: :user, text: "Hello!")
+      expect(msgs.last[:timestamp]).to be_a(Time)
     end
 
-    it "push_assistant_message adds an assistant message" do
+    it "push_assistant_message adds an assistant message with timestamp" do
       tui.send(:push_assistant_message, "Hi there")
       msgs = tui.instance_variable_get(:@messages)
       expect(msgs.last).to include(role: :assistant, text: "Hi there")
+      expect(msgs.last[:timestamp]).to be_a(Time)
     end
 
-    it "push_info_message adds an info message" do
+    it "push_info_message adds an info message with timestamp" do
       tui.send(:push_info_message, "Info text")
       msgs = tui.instance_variable_get(:@messages)
       expect(msgs.last).to include(role: :info, text: "Info text")
+      expect(msgs.last[:timestamp]).to be_a(Time)
     end
 
-    it "push_error_message adds an error message" do
+    it "push_error_message adds an error message with timestamp" do
       tui.send(:push_error_message, "Something broke")
       msgs = tui.instance_variable_get(:@messages)
       expect(msgs.last).to include(role: :error, text: "Something broke")
+      expect(msgs.last[:timestamp]).to be_a(Time)
     end
   end
 
-  # ── Render Helpers ────────────────────────────────────────────────
+  # ── Render Helpers (MessageRenderer via build_chat_lines) ───────────
 
-  describe "#render_message" do
-    subject(:tui) { described_class.new(config:) }
+  describe "#build_chat_lines with message rendering" do
+    subject(:tui) do
+      t = described_class.new(config:)
+      allow(t).to receive_messages(detect_width: 80, detect_height: 24)
+      t
+    end
 
     it "renders a user message with the 'You' prefix" do
-      msg   = { role: :user, text: "Hello world" }
-      lines = tui.send(:render_message, msg, 80)
+      tui.send(:push_user_message, "Hello world")
+      lines = tui.send(:build_chat_lines)
       joined = lines.join
       expect(joined).to include("You")
       expect(joined).to include("Hello world")
     end
 
     it "renders an assistant message with the agent name prefix" do
-      msg   = { role: :assistant, text: "I can help" }
-      lines = tui.send(:render_message, msg, 80)
+      tui.send(:push_assistant_message, "I can help")
+      lines = tui.send(:build_chat_lines)
       joined = lines.join
       expect(joined).to include(described_class::AGENT_NAME)
       expect(joined).to include("I can help")
@@ -218,36 +242,24 @@ RSpec.describe Homunculus::Interfaces::TUI do
 
     it "wraps long lines at the specified width" do
       long_text = "word " * 30
-      msg       = { role: :user, text: long_text.strip }
-      lines     = tui.send(:render_message, msg, 40)
+      tui.send(:push_user_message, long_text.strip)
+      lines = tui.send(:build_chat_lines)
       raw_lines = lines.map { |l| tui.send(:visible_len, l) }
-      expect(raw_lines.all? { |len| len <= 41 }).to be true
+      expect(raw_lines.all? { |len| len <= 82 }).to be true
     end
   end
 
-  # ── Role Labels ───────────────────────────────────────────────────
-
-  describe "#role_label" do
-    subject(:tui) { described_class.new(config:) }
-
-    it "returns 'You' for :user" do
-      expect(tui.send(:role_label, :user)).to eq("You")
+  describe "MessageRenderer (role labels)" do
+    it "role_label returns You for user via MessageRenderer" do
+      r = described_class::MessageRenderer.new(width: 80)
+      lines = r.render({ role: :user, text: "x", timestamp: nil })
+      expect(lines.join).to include("You")
     end
 
-    it "returns agent name for :assistant" do
-      expect(tui.send(:role_label, :assistant)).to eq(described_class::AGENT_NAME)
-    end
-
-    it "returns 'System' for :system" do
-      expect(tui.send(:role_label, :system)).to eq("System")
-    end
-
-    it "returns 'Error' for :error" do
-      expect(tui.send(:role_label, :error)).to eq("Error")
-    end
-
-    it "capitalizes unknown roles" do
-      expect(tui.send(:role_label, :info)).to eq("Info")
+    it "role_label returns agent name for assistant via MessageRenderer" do
+      r = described_class::MessageRenderer.new(width: 80)
+      lines = r.render({ role: :assistant, text: "x", timestamp: nil })
+      expect(lines.join).to include(described_class::AGENT_NAME)
     end
   end
 
@@ -259,7 +271,8 @@ RSpec.describe Homunculus::Interfaces::TUI do
       tui.instance_variable_set(:@session, Homunculus::Session.new)
       content = tui.send(:status_bar_content)
       expect(tui.send(:visible_len, content)).to be > 0
-      expect(content).to include("model:")
+      expect(content).to include("◆")
+      expect(content).to include("router")
     end
 
     it "includes token counts when session is set" do
@@ -273,7 +286,150 @@ RSpec.describe Homunculus::Interfaces::TUI do
       tui = described_class.new(config:)
       tui.instance_variable_set(:@session, Homunculus::Session.new)
       content = tui.send(:status_bar_content)
-      expect(content).to include("turns:")
+      expect(content).to include("turn ")
+      expect(content).to include("/25")
+    end
+
+    it "shows spinner frame and message when activity indicator is running (Story 3)" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@session, Homunculus::Session.new)
+      allow(tui).to receive(:refresh_status_bar)
+      indicator = tui.instance_variable_get(:@activity_indicator)
+      indicator.start("Thinking...")
+      content = tui.send(:status_bar_content)
+      indicator.stop
+      expect(content).to include("Thinking...")
+      expect(content).to match(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/)
+    end
+
+    it "includes resolved tier and model when @current_tier and @current_model set (Story 8)" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@session, Homunculus::Session.new)
+      tui.instance_variable_set(:@current_tier, "workhorse")
+      tui.instance_variable_set(:@current_model, "qwen3:14b")
+      allow(tui).to receive(:use_models_router?).and_return(true)
+      content = tui.send(:status_bar_content)
+      expect(content).to include("workhorse")
+      expect(content).to include("tokens:")
+    end
+
+    it "includes escalation text when @current_escalated_from set (Story 8)" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@session, Homunculus::Session.new)
+      tui.instance_variable_set(:@current_tier, "cloud_fast")
+      tui.instance_variable_set(:@current_model, "claude-haiku")
+      tui.instance_variable_set(:@current_escalated_from, "workhorse")
+      allow(tui).to receive(:use_models_router?).and_return(true)
+      content = tui.send(:status_bar_content)
+      expect(content).to include("cloud_fast")
+      expect(content).to include("escalated from workhorse")
+    end
+
+    it "applies green ANSI to model segment for local tier (Story 8)" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@session, Homunculus::Session.new)
+      tui.instance_variable_set(:@current_tier, "workhorse")
+      tui.instance_variable_set(:@current_model, "qwen3:14b")
+      allow(tui).to receive(:use_models_router?).and_return(true)
+      content = tui.send(:status_bar_content)
+      expect(content).to include("\e[32m") # green
+    end
+
+    it "applies yellow ANSI to model segment for cloud tier (Story 8)" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@session, Homunculus::Session.new)
+      tui.instance_variable_set(:@current_tier, "cloud_fast")
+      tui.instance_variable_set(:@current_model, "claude-haiku")
+      allow(tui).to receive(:use_models_router?).and_return(true)
+      content = tui.send(:status_bar_content)
+      expect(content).to include("\e[33m") # yellow
+    end
+
+    it "applies red background to model segment when escalated (Story 8)" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@session, Homunculus::Session.new)
+      tui.instance_variable_set(:@current_tier, "cloud_fast")
+      tui.instance_variable_set(:@current_model, "claude-haiku")
+      tui.instance_variable_set(:@current_escalated_from, "workhorse")
+      allow(tui).to receive(:use_models_router?).and_return(true)
+      content = tui.send(:status_bar_content)
+      expect(content).to include("\e[41m") # bg_red
+    end
+
+    it "includes elapsed session time when @session_start_time is set (Story 6)" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@session, Homunculus::Session.new)
+      tui.instance_variable_set(:@session_start_time, Time.now - 125)
+      content = tui.send(:status_bar_content)
+      expect(content).to match(/\d+m\s+\d+s/)
+    end
+
+    it "shows ↕ scrolled when @scroll_offset > 0 (Story 6)" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@session, Homunculus::Session.new)
+      tui.instance_variable_set(:@scroll_offset, 5)
+      content = tui.send(:status_bar_content)
+      expect(content).to include("↕ scrolled")
+    end
+
+    it "shows ⚠ awaiting confirm when pending_tool_call (Story 6)" do
+      tui = described_class.new(config:)
+      session = Homunculus::Session.new
+      session.pending_tool_call = Homunculus::Agent::ModelProvider::ToolCall.new(
+        id: "x", name: "shell_exec", arguments: {}
+      )
+      tui.instance_variable_set(:@session, session)
+      content = tui.send(:status_bar_content)
+      expect(content).to include("awaiting confirm")
+    end
+  end
+
+  describe "#model_tier_label" do
+    it "returns tier and model when @current_tier and @current_model set" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@current_tier, "workhorse")
+      tui.instance_variable_set(:@current_model, "qwen3:14b")
+      allow(tui).to receive(:use_models_router?).and_return(true)
+      expect(tui.send(:model_tier_label)).to eq("model: workhorse (qwen3:14b)")
+    end
+
+    it "appends escalation suffix when @current_escalated_from set" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@current_tier, "cloud_fast")
+      tui.instance_variable_set(:@current_model, "claude-haiku")
+      tui.instance_variable_set(:@current_escalated_from, "workhorse")
+      allow(tui).to receive(:use_models_router?).and_return(true)
+      expect(tui.send(:model_tier_label)).to include("⚡ escalated from workhorse")
+    end
+
+    it "falls back to router when no current tier and models_router" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@current_tier, nil)
+      allow(tui).to receive(:use_models_router?).and_return(true)
+      expect(tui.send(:model_tier_label)).to eq("model: router")
+    end
+  end
+
+  describe "#model_tier_style and #cloud_tier?" do
+    it "returns :green for local tier" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@current_tier, "workhorse")
+      tui.instance_variable_set(:@current_escalated_from, nil)
+      expect(tui.send(:model_tier_style)).to eq(:green)
+    end
+
+    it "returns :yellow for cloud tier" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@current_tier, "cloud_fast")
+      tui.instance_variable_set(:@current_escalated_from, nil)
+      expect(tui.send(:model_tier_style)).to eq(:yellow)
+    end
+
+    it "returns :bg_red when escalated_from set" do
+      tui = described_class.new(config:)
+      tui.instance_variable_set(:@current_tier, "cloud_fast")
+      tui.instance_variable_set(:@current_escalated_from, "workhorse")
+      expect(tui.send(:model_tier_style)).to eq(:bg_red)
     end
   end
 
@@ -313,11 +469,13 @@ RSpec.describe Homunculus::Interfaces::TUI do
       expect(tui.instance_variable_get(:@running)).to be true
     end
 
-    it "pushes help info on 'help'" do
+    it "does not add help to @messages when show_help is called (overlay only)" do
       allow(tui).to receive(:handle_message)
-      tui.send(:process_input, "help")
+      tui.send(:show_help)
+      tui.send(:show_help)
       msgs = tui.instance_variable_get(:@messages)
-      expect(msgs.any? { |m| m[:role] == :info && m[:text].include?("TUI Commands") }).to be true
+      help_entries = msgs.select { |m| m[:role] == :info && m[:text].to_s.include?("Here's what I can do") }
+      expect(help_entries.size).to eq(0)
     end
 
     it "clears messages on 'clear'" do
@@ -330,6 +488,80 @@ RSpec.describe Homunculus::Interfaces::TUI do
       allow(tui).to receive(:handle_message).with("hello world")
       tui.send(:process_input, "hello world")
       expect(tui).to have_received(:handle_message).with("hello world")
+    end
+
+    it "dispatches /help to show_help (slash command)" do
+      allow(tui).to receive(:show_help)
+      tui.send(:process_input, "/help")
+      expect(tui).to have_received(:show_help)
+    end
+
+    it "dispatches /status to show_status" do
+      allow(tui).to receive(:show_status)
+      tui.send(:process_input, "/status")
+      expect(tui).to have_received(:show_status)
+    end
+
+    it "shows unknown command overlay for /unknown" do
+      tui.send(:process_input, "/unknown")
+      overlay = tui.instance_variable_get(:@overlay_content)
+      expect(overlay).not_to be_nil
+      expect(overlay.join).to include("Unknown command")
+      expect(overlay.join).to include("/help")
+    end
+
+    it "bare 'help' still calls show_help (backward compat)" do
+      allow(tui).to receive(:show_help)
+      tui.send(:process_input, "help")
+      expect(tui).to have_received(:show_help)
+    end
+
+    it "bare 'status' still calls show_status (backward compat)" do
+      allow(tui).to receive(:show_status)
+      tui.send(:process_input, "status")
+      expect(tui).to have_received(:show_status)
+    end
+
+    it "/quit sets @running to false" do
+      tui.send(:process_input, "/quit")
+      expect(tui.instance_variable_get(:@running)).to be false
+    end
+
+    it "dispatches /model to show_model" do
+      allow(tui).to receive(:show_model)
+      tui.send(:process_input, "/model")
+      expect(tui).to have_received(:show_model)
+    end
+  end
+
+  describe "#apply_tab_completion" do
+    subject(:tui) do
+      described_class.new(config:)
+    end
+
+    it "completes buffer to first suggestion when buffer is prefix" do
+      buf = Homunculus::Interfaces::TUI::InputBuffer.new
+      buf.insert("/")
+      buf.insert("h")
+      buf.insert("e")
+      tui.instance_variable_set(:@suggestion_lines, ["/help"])
+      tui.send(:apply_tab_completion, buf)
+      expect(buf.to_s).to eq("/help")
+    end
+
+    it "returns false when buffer does not start with /" do
+      buf = Homunculus::Interfaces::TUI::InputBuffer.new
+      buf.insert("help")
+      tui.instance_variable_set(:@suggestion_lines, ["/help"])
+      expect(tui.send(:apply_tab_completion, buf)).to be false
+      expect(buf.to_s).to eq("help")
+    end
+
+    it "returns false when no suggestions" do
+      buf = Homunculus::Interfaces::TUI::InputBuffer.new
+      buf.insert("/x")
+      tui.instance_variable_set(:@suggestion_lines, [])
+      expect(tui.send(:apply_tab_completion, buf)).to be false
     end
   end
 
@@ -352,7 +584,7 @@ RSpec.describe Homunculus::Interfaces::TUI do
       expect(msgs.any? { |m| m[:role] == :assistant && m[:text] == "Done!" }).to be true
     end
 
-    it "pushes info message on :pending_confirmation status" do
+    it "pushes tool_request message on :pending_confirmation status" do
       tool_call = Homunculus::Agent::ModelProvider::ToolCall.new(
         id: "tc-1", name: "shell_exec", arguments: { command: "ls" }
       )
@@ -362,7 +594,7 @@ RSpec.describe Homunculus::Interfaces::TUI do
       )
       tui.send(:display_result, result)
       msgs = tui.instance_variable_get(:@messages)
-      expect(msgs.any? { |m| m[:role] == :info && m[:text].include?("shell_exec") }).to be true
+      expect(msgs.any? { |m| m[:role] == :tool_request && m[:tool_name] == "shell_exec" }).to be true
     end
 
     it "pushes error message on :error status" do
@@ -370,6 +602,30 @@ RSpec.describe Homunculus::Interfaces::TUI do
       tui.send(:display_result, result)
       msgs = tui.instance_variable_get(:@messages)
       expect(msgs.any? { |m| m[:role] == :error && m[:text].include?("Boom") }).to be true
+    end
+
+    it "sets @current_tier, @current_model, @current_escalated_from from completed result (Story 8)" do
+      result = Homunculus::Agent::AgentResult.completed(
+        "Done!",
+        session: tui.instance_variable_get(:@session),
+        tier: "workhorse", model: "qwen3:14b", escalated_from: nil
+      )
+      allow(tui).to receive(:use_models_router?).and_return(true)
+      tui.send(:display_result, result)
+      expect(tui.instance_variable_get(:@current_tier)).to eq("workhorse")
+      expect(tui.instance_variable_get(:@current_model)).to eq("qwen3:14b")
+      expect(tui.instance_variable_get(:@current_escalated_from)).to be_nil
+    end
+
+    it "sets @current_escalated_from when result has escalation (Story 8)" do
+      result = Homunculus::Agent::AgentResult.completed(
+        "Done!",
+        session: tui.instance_variable_get(:@session),
+        tier: "cloud_fast", model: "claude-haiku", escalated_from: "workhorse"
+      )
+      allow(tui).to receive(:use_models_router?).and_return(true)
+      tui.send(:display_result, result)
+      expect(tui.instance_variable_get(:@current_escalated_from)).to eq("workhorse")
     end
   end
 
@@ -501,7 +757,7 @@ RSpec.describe Homunculus::Interfaces::TUI do
 
     it "render_input_line writes prompt" do
       tui.send(:render_input_line, "test input")
-      expect(stdout_buf).to include(">")
+      expect(stdout_buf).to include(described_class::Theme::PROMPT_CHAR)
     end
 
     it "initial_render calls all sub-renders" do
@@ -590,6 +846,88 @@ RSpec.describe Homunculus::Interfaces::TUI do
       cb.call("second")
       expect(tui.instance_variable_get(:@messages).length).to eq(count_after_first)
     end
+
+    it "sets timestamp on streaming message when first chunk arrives" do
+      cb = tui.send(:build_stream_callback)
+      cb.call("first chunk")
+      buf = tui.instance_variable_get(:@streaming_buf)
+      expect(buf[:timestamp]).to be_a(Time)
+    end
+
+    it "stops activity indicator on first chunk (Story 3)" do
+      indicator = tui.instance_variable_get(:@activity_indicator)
+      allow(indicator).to receive(:stop).and_call_original
+      cb = tui.send(:build_stream_callback)
+      cb.call("first")
+      expect(indicator).to have_received(:stop)
+    end
+
+    it "updates streaming_output_tokens_estimate as chunks arrive (Story 4)" do
+      cb = tui.send(:build_stream_callback)
+      cb.call("one")
+      estimate1 = tui.instance_variable_get(:@streaming_output_tokens_estimate)
+      expect(estimate1).to be_a(Integer)
+      expect(estimate1).to be >= 1
+      cb.call(" two three four five")
+      estimate2 = tui.instance_variable_get(:@streaming_output_tokens_estimate)
+      expect(estimate2).to be > estimate1
+    end
+
+    it "sets streaming_output_tokens_estimate from word and char heuristic" do
+      cb = tui.send(:build_stream_callback)
+      cb.call("hello world")
+      estimate = tui.instance_variable_get(:@streaming_output_tokens_estimate)
+      expect(estimate).to be_a(Integer)
+      expect(estimate).to be >= 1
+    end
+  end
+
+  # ── token_usage_label (Story 4) ───────────────────────────────────
+
+  describe "#token_usage_label" do
+    it "returns nil when session is nil" do
+      tui = described_class.new(config:)
+      expect(tui.instance_variable_get(:@session)).to be_nil
+      expect(tui.send(:token_usage_label)).to be_nil
+    end
+
+    it "shows session totals only when no streaming estimate" do
+      tui = described_class.new(config:)
+      session = Homunculus::Session.new
+      usage = Homunculus::Agent::ModelProvider::TokenUsage.new(input_tokens: 100, output_tokens: 50)
+      session.track_usage(usage)
+      tui.instance_variable_set(:@session, session)
+      label = tui.send(:token_usage_label)
+      expect(label).to eq("tokens: 100↓ 50↑")
+    end
+
+    it "includes streaming estimate when set (Story 4)" do
+      tui = described_class.new(config:)
+      session = Homunculus::Session.new
+      session.track_usage(
+        Homunculus::Agent::ModelProvider::TokenUsage.new(input_tokens: 200, output_tokens: 80)
+      )
+      tui.instance_variable_set(:@session, session)
+      tui.instance_variable_set(:@streaming_output_tokens_estimate, 15)
+      label = tui.send(:token_usage_label)
+      expect(label).to include("95↑") # 80 + 15
+      expect(label).to include("+15⚡")
+    end
+
+    it "shows session totals after estimate cleared" do
+      tui = described_class.new(config:)
+      session = Homunculus::Session.new
+      session.track_usage(
+        Homunculus::Agent::ModelProvider::TokenUsage.new(input_tokens: 300, output_tokens: 120)
+      )
+      tui.instance_variable_set(:@session, session)
+      tui.instance_variable_set(:@streaming_output_tokens_estimate, 10)
+      tui.instance_variable_get(:@messages_mutex).synchronize do
+        tui.instance_variable_set(:@streaming_output_tokens_estimate, nil)
+      end
+      label = tui.send(:token_usage_label)
+      expect(label).to eq("tokens: 300↓ 120↑")
+    end
   end
 
   # ── handle_message ────────────────────────────────────────────────
@@ -635,6 +973,111 @@ RSpec.describe Homunculus::Interfaces::TUI do
       tui.send(:handle_message, "hello")
       msgs = tui.instance_variable_get(:@messages)
       expect(msgs.any? { |m| m[:role] == :error && m[:text].include?("network down") }).to be true
+    end
+
+    it "runs agent in a background thread so main thread can process scroll (wait loop exits when thread finishes)" do
+      agent_loop = tui.instance_variable_get(:@agent_loop)
+      session = tui.instance_variable_get(:@session)
+      allow(agent_loop).to receive(:run).and_return(
+        Homunculus::Agent::AgentResult.completed("done", session:)
+      )
+      tui.send(:handle_message, "ping")
+      expect(tui).to have_received(:display_result).with(
+        Homunculus::Agent::AgentResult.completed("done", session:)
+      )
+    end
+
+    it "starts activity indicator before agent and stops it in ensure (Story 3)" do
+      agent_loop = tui.instance_variable_get(:@agent_loop)
+      session = tui.instance_variable_get(:@session)
+      allow(agent_loop).to receive(:run).and_return(
+        Homunculus::Agent::AgentResult.completed("ok", session:)
+      )
+      indicator = tui.instance_variable_get(:@activity_indicator)
+      allow(indicator).to receive(:start).and_call_original
+      allow(indicator).to receive(:stop).and_call_original
+      tui.send(:handle_message, "hello")
+      expect(indicator).to have_received(:start).with("Thinking...")
+      expect(indicator).to have_received(:stop)
+    end
+
+    it "clears streaming_output_tokens_estimate after agent completes (Story 4)" do
+      agent_loop = tui.instance_variable_get(:@agent_loop)
+      session = tui.instance_variable_get(:@session)
+      allow(agent_loop).to receive(:run).and_return(
+        Homunculus::Agent::AgentResult.completed("done", session:)
+      )
+      tui.instance_variable_set(:@streaming_output_tokens_estimate, 42)
+      tui.send(:handle_message, "ping")
+      expect(tui.instance_variable_get(:@streaming_output_tokens_estimate)).to be_nil
+    end
+  end
+
+  # ── Story 2: Mutex and scroll during agent ─────────────────────────
+
+  describe "message buffer mutex and scroll during streaming" do
+    subject(:tui) do
+      t = described_class.new(config:)
+      t.instance_variable_set(:@session, Homunculus::Session.new)
+      allow(t).to receive_messages(detect_width: 80, detect_height: 24)
+      t
+    end
+
+    it "allows concurrent stream callback and build_chat_lines without raising" do
+      cb = tui.send(:build_stream_callback)
+      reader = Thread.new do
+        20.times { tui.send(:build_chat_lines) }
+      end
+      writer = Thread.new do
+        20.times { |i| cb.call(" chunk #{i}") }
+      end
+      expect do
+        reader.join(2)
+        writer.join(2)
+      end.not_to raise_error
+    end
+
+    it "handle_scroll_keys updates scroll_offset and can be called while messages exist (mutex-held reads)" do
+      tui.send(:push_user_message, "one")
+      tui.send(:push_assistant_message, "two")
+      allow(tui).to receive(:refresh_chat_panel)
+      tui.send(:handle_scroll_keys, "[5~")
+      expect(tui.instance_variable_get(:@scroll_offset)).to be >= 0
+    end
+  end
+
+  describe "scroll indicators in render_chat_panel" do
+    subject(:tui) do
+      t = described_class.new(config:)
+      t.instance_variable_set(:@session, Homunculus::Session.new)
+      allow(t).to receive_messages(detect_width: 80, detect_height: 24, chat_rows: 6)
+      t
+    end
+
+    let(:stdout_buf) { +"" }
+
+    before do
+      allow($stdout).to receive(:write) { |s| stdout_buf << s.to_s }
+      allow($stdout).to receive(:flush)
+    end
+
+    it "shows ▲ more above when scrolled up and not at top" do
+      5.times { |i| tui.send(:push_user_message, "msg #{i} " + ("x " * 20)) }
+      # Many lines so max_scroll is large; scroll_offset 2 leaves content above
+      tui.instance_variable_set(:@scroll_offset, 2)
+      tui.send(:render_chat_panel)
+      raw = stdout_buf.gsub(/\e\[[0-9;]*[mGKHF]/, "")
+      expect(raw).to include("▲ more above")
+    end
+
+    it "shows ▼ more below when user has scrolled up (scroll_offset > 0)" do
+      tui.send(:push_user_message, "line 1")
+      long_content = "word " * 30
+      tui.send(:push_assistant_message, "line 2 #{long_content}")
+      tui.instance_variable_set(:@scroll_offset, 3)
+      tui.send(:render_chat_panel)
+      raw = stdout_buf.gsub(/\e\[[0-9;]*[mGKHF]/, "")
+      expect(raw).to include("▼ more below")
     end
   end
 
@@ -693,7 +1136,25 @@ RSpec.describe Homunculus::Interfaces::TUI do
     end
   end
 
-  # ── show_status ───────────────────────────────────────────────────
+  # ── show_help / show_status (overlay, no duplicate) ─────────────────
+
+  describe "#show_help" do
+    subject(:tui) do
+      t = described_class.new(config:)
+      t.instance_variable_set(:@session, Homunculus::Session.new)
+      t
+    end
+
+    before { allow(tui).to receive(:refresh_all) }
+
+    it "sets overlay content and does not push to @messages" do
+      tui.send(:show_help)
+      expect(tui.instance_variable_get(:@messages)).to be_empty
+      overlay = tui.instance_variable_get(:@overlay_content)
+      expect(overlay).not_to be_nil
+      expect(overlay.join).to include("Here's what I can do")
+    end
+  end
 
   describe "#show_status" do
     subject(:tui) do
@@ -704,13 +1165,60 @@ RSpec.describe Homunculus::Interfaces::TUI do
 
     before { allow(tui).to receive(:refresh_all) }
 
-    it "pushes a status info message" do
+    it "sets overlay content and does not push to @messages" do
       tui.send(:show_status)
       msgs = tui.instance_variable_get(:@messages)
-      info = msgs.find { |m| m[:role] == :info }
-      expect(info).not_to be_nil
-      expect(info[:text]).to include("Session:")
-      expect(info[:text]).to include("Turns:")
+      expect(msgs).to be_empty
+      overlay = tui.instance_variable_get(:@overlay_content)
+      expect(overlay).not_to be_nil
+      expect(overlay.join).to include("Session:")
+      expect(overlay.join).to include("Turns:")
+    end
+  end
+
+  describe "#show_model" do
+    subject(:tui) do
+      t = described_class.new(config:)
+      t.instance_variable_set(:@session, Homunculus::Session.new)
+      t
+    end
+
+    before { allow(tui).to receive(:refresh_all) }
+
+    it "sets overlay with tier, model, provider (Story 7)" do
+      tui.send(:show_model)
+      overlay = tui.instance_variable_get(:@overlay_content)
+      expect(overlay).not_to be_nil
+      expect(overlay.join).to match(/Model tier:|model:|Model:|Provider:/i)
+    end
+  end
+
+  describe "overlay rendering and clearing" do
+    subject(:tui) do
+      t = described_class.new(config:)
+      t.instance_variable_set(:@session, Homunculus::Session.new)
+      t.instance_variable_set(:@running, true)
+      t
+    end
+
+    before do
+      allow(tui).to receive(:refresh_all)
+      allow(tui).to receive(:render_input_line)
+    end
+
+    it "build_chat_lines returns overlay content when @overlay_content is set" do
+      tui.instance_variable_set(:@overlay_content, %w[line1 line2])
+      allow(tui).to receive(:inner_width).and_return(80)
+      lines = tui.send(:build_chat_lines)
+      raw = lines.map { |l| l.gsub(/\e\[[0-9;]*[mGKHF]/, "") }
+      expect(raw.join).to include("line1")
+      expect(raw.join).to include("line2")
+    end
+
+    it "process_input clears overlay" do
+      tui.instance_variable_set(:@overlay_content, ["overlay line"])
+      tui.send(:process_input, "clear")
+      expect(tui.instance_variable_get(:@overlay_content)).to be_nil
     end
   end
 
@@ -732,12 +1240,16 @@ RSpec.describe Homunculus::Interfaces::TUI do
       expect(described_class::CHROME_ROWS).to eq(expected)
     end
 
-    it "ROLE_COLORS includes all expected roles" do
-      expect(described_class::ROLE_COLORS).to include(:user, :assistant, :system, :error, :info)
+    it "Theme palette includes semantic role colors" do
+      palette = described_class::Theme.palette
+      expect(palette).to include(:user, :assistant, :info, :error, :muted, :accent)
     end
 
-    it "ANSI_CODES includes essential keys" do
-      expect(described_class::ANSI_CODES).to include(:reset, :bold, :dim, :cyan, :green, :red, :reverse)
+    it "Theme.paint applies styles and resets" do
+      result = described_class::Theme.paint("hello", :bold)
+      expect(result).to include("\e[1m")
+      expect(result).to include("hello")
+      expect(result).to include("\e[0m")
     end
   end
 end


### PR DESCRIPTION
- Theme: 256-color palette, semantic styles, decorative constants (lib/homunculus/interfaces/tui/theme.rb)
- MessageRenderer: markdown (bold, italic, code, lists, blocks), tool request cards (message_renderer.rb)
- Visual rhythm: role indicators, turn/date separators, padding (build_chat_lines)
- Warm welcome: time-aware greeting, session context, soft errors, help overlay copy
- Status bar: session timer, dot separators, scroll/awaiting-confirm hints, muted styling
- Input: placeholder, char count >100, Ctrl+U/L, slash suggestions with descriptions
- Session summary and farewell on exit (print_session_summary)
- Header: centered title with flanking, day-of-week date, tagline/separator
- Fix: clear suggestion rows when input no longer starts with / (no stale /confirm line)

Made-with: Cursor